### PR TITLE
Reworking transforms for flexibility and fewer allocations

### DIFF
--- a/examples/scaling_transforms.rs
+++ b/examples/scaling_transforms.rs
@@ -9,7 +9,7 @@ use polyfit::{
         plotters::{Plot, Root, Split},
         PlotOptions, PlottingElement,
     },
-    transforms::{ApplyScale, ScaleTransform, Transform},
+    transforms::{ApplyScale, ScaleTransform, Transform, XTransform},
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Let's also convert time to minutes
     // The trait applies to y, so let's apply it manually
     let transformation = ScaleTransform::Linear(1.0 / 60.0);
-    transformation.apply(voltage_data.iter_mut().map(|(x, _)| x));
+    XTransform(transformation).apply::<Vec<_>>(&mut voltage_data);
 
     //
     // Let's plot these side-by-side

--- a/examples/transforms_demo.rs
+++ b/examples/transforms_demo.rs
@@ -277,15 +277,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //
     // Exponential
     let data = SourceSampleType::GrowingSlow(false).generate();
-    let base2_1 = ScaleTransform::Exponential(2.0, 1.0);
-    let basee = ScaleTransform::Exponential(2.0, 0.5);
-    let tiny_coeff = ScaleTransform::Exponential(std::f64::consts::E, 0.01);
+    let base2 = ScaleTransform::Exponential(2.0);
+    let base3 = ScaleTransform::Exponential(3.0);
+    let basee = ScaleTransform::Exponential(std::f64::consts::E);
     generate_plot(
         data.clone(),
         vec![
-            ("Exponential base=2, factor=1.0", data.transformed(&base2_1)),
-            ("Exponential base=2, factor=0.5", data.transformed(&basee)),
-            ("Exponential base=e, factor=0.01", data.transformed(&tiny_coeff)),
+            ("Exponential base=2", data.transformed(&base2)),
+            ("Exponential base=3", data.transformed(&base3)),
+            ("Exponential base=e", data.transformed(&basee)),
         ],
         false,
         "Exponential Transform",
@@ -295,8 +295,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //
     // Logarithmic (base, factor)
     let data = SourceSampleType::GrowingSlow(false).generate().apply_shift_scale(10.0);
-    let log_base_10 = ScaleTransform::Logarithmic(10.0, 2.0);
-    let log_base_e = ScaleTransform::Logarithmic(std::f64::consts::E, 1.0);
+    let log_base_10 = ScaleTransform::Logarithmic(10.0);
+    let log_base_e = ScaleTransform::Logarithmic(std::f64::consts::E);
 
     generate_plot(
         data.clone(),

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -65,6 +65,9 @@ use std::borrow::BorrowMut;
 
 use crate::value::Value;
 
+mod adapters;
+pub use adapters::{XTransform, YTransform};
+
 mod noise;
 pub use noise::{ApplyNoise, NoiseTransform, Strength};
 
@@ -79,13 +82,30 @@ pub use rand;
 pub use rand_distr;
 
 /// Trait for applying transformations to data.
-pub trait Transform<T: Value> {
+pub trait Transform<T> {
     /// Applies the transformation to the given data.
-    fn apply<'a>(&self, data: impl Iterator<Item = &'a mut T>);
+    ///
+    /// Taking a mutable reference to something implementing `IntoIterator`
+    /// allows transforms to take multiple passes over the data.
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>;
 
     /// Applies the transformation to a single data point.
-    fn apply_to(&self, point: &mut T) {
-        self.apply(std::iter::once(point));
+    ///
+    /// Beware that this only makes sense for *pure* transforms that are independent
+    /// of other points in the data.  For example, it's fine with [`ScaleTransform`]s
+    /// and [`NoiseTransform::Uniform`]-with-[`Strength::Absolute`] and
+    /// [`NormalizationTransform::Clip`], but not with [`NormalizationTransform::LogOffset`]
+    /// nor [`NoiseTransform::Uniform`]-with-[`Strength::Relative`] nor
+    /// [`SmoothingTransform::Gaussian`].
+    fn apply_to(&self, point: &mut T)
+    where
+        T: Copy,
+    {
+        let mut single = [*point];
+        self.apply::<[T; 1]>(&mut single);
+        [*point] = single;
     }
 }
 
@@ -94,13 +114,37 @@ pub trait Transform<T: Value> {
 /// This way if you don't need to re-use a transform, you can pass it directly,
 /// but you can still pass large ones by reference where that's helpful.
 impl<T: Value, R: ?Sized + Transform<T>> Transform<T> for &R {
-    fn apply<'a>(&self, data: impl Iterator<Item = &'a mut T>) {
-        <R as Transform<T>>::apply(*self, data);
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>,
+    {
+        <R as Transform<T>>::apply::<I>(*self, data);
+    }
+}
+
+/// Applies each of the transforms in the slice in order.
+impl<T: Value, E: Transform<T>> Transform<T> for [E] {
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>,
+    {
+        for transform in self {
+            transform.apply::<I>(data);
+        }
+    }
+}
+/// Applies each of the transforms in the array in order.
+impl<T: Value, E: Transform<T>, const N: usize> Transform<T> for [E; N] {
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>,
+    {
+        self.as_slice().apply::<I>(data);
     }
 }
 
 /// Trait for transforming data.
-pub trait Transformable<T: Value> {
+pub trait Transformable<T> {
     /// Transforms the data in place.
     fn transform<R: Transform<T>>(&mut self, transform: R);
 
@@ -116,9 +160,18 @@ pub trait Transformable<T: Value> {
         new_data
     }
 }
+impl<T: Value> Transformable<T> for [T] {
+    fn transform<R: Transform<T>>(&mut self, transform: R) {
+        transform.apply::<Self>(self);
+    }
+}
+/// Applies the transform to the second ("y") element of the pairs.
+///
+/// See [`XTransform`] if you're trying to modify the first ("x") element,
+/// or [`YTransform`] for what this uses internally.
 impl<T: Value> Transformable<T> for [(T, T)] {
     fn transform<R: Transform<T>>(&mut self, transform: R) {
-        transform.apply(self.iter_mut().map(|(_, y)| y));
+        YTransform(transform).apply::<Self>(self);
     }
 }
 

--- a/src/transforms/adapters.rs
+++ b/src/transforms/adapters.rs
@@ -1,0 +1,54 @@
+use crate::transforms::Transform;
+
+/// Wraps a [`Transform`] that applies to a scalar so that it applies
+/// to the first ("x") coordinate in a pair instead.
+pub struct XTransform<R>(pub R);
+impl<A: 'static, B: 'static, R: Transform<A>> Transform<(A, B)> for XTransform<R> {
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut (A, B)>,
+    {
+        // We need a full function, not just a closure, to force the lifetime to match.
+        fn first_mut<A, B>(pair: &mut (A, B)) -> &mut A {
+            &mut pair.0
+        }
+
+        let mut mapped = IntoIterMutMap(data, first_mut::<A, B>);
+        self.0.apply::<IntoIterMutMap<'_, I, _>>(&mut mapped);
+    }
+}
+
+/// Wraps a [`Transform`] that applies to a scalar so that it applies
+/// to the second ("y") coordinate in a pair instead.
+///
+/// Note that you usually don't need to do this yourself, as [`Transformable`]
+/// on pairs defaults to applying this way.
+pub struct YTransform<R>(pub R);
+impl<A: 'static, B: 'static, R: Transform<B>> Transform<(A, B)> for YTransform<R> {
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut (A, B)>,
+    {
+        // We need a full function, not just a closure, to force the lifetime to match.
+        fn second_mut<A, B>(pair: &mut (A, B)) -> &mut B {
+            &mut pair.1
+        }
+
+        let mut mapped = IntoIterMutMap(data, second_mut::<A, B>);
+        self.0.apply::<IntoIterMutMap<'_, I, _>>(&mut mapped);
+    }
+}
+
+struct IntoIterMutMap<'inner, I: ?Sized, F>(&'inner mut I, F);
+impl<'outer, I: ?Sized, F, A: 'outer, B: 'outer> IntoIterator
+    for &'outer mut IntoIterMutMap<'_, I, F>
+where
+    &'outer mut I: IntoIterator<Item = &'outer mut A>,
+    F: Fn(&mut A) -> &mut B,
+{
+    type IntoIter = std::iter::Map<<&'outer mut I as IntoIterator>::IntoIter, &'outer mut F>;
+    type Item = &'outer mut B;
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIterator::into_iter(&mut *self.0).map(&mut self.1)
+    }
+}

--- a/src/transforms/noise.rs
+++ b/src/transforms/noise.rs
@@ -3,7 +3,7 @@ use rand_distr::{Bernoulli, Beta, Distribution, Normal, Poisson, Uniform};
 
 use crate::{
     statistics::DomainNormalizer,
-    transforms::{SeedSource, Transform},
+    transforms::{SeedSource, Transform, Transformable},
     value::{FloatClampedCast, Value},
 };
 
@@ -28,21 +28,27 @@ impl<T: Value> Strength<T> {
     /// Get a strength-ajusted std-dev for some data
     ///
     /// Does not mutate data - but this is the form the transforms get
-    pub(crate) fn into_stddev(self, data: &[&mut T]) -> T {
+    pub(crate) fn into_stddev<I: ?Sized>(self, data: &mut I) -> T
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>,
+    {
         let mut std_dev = match self {
             Strength::Absolute(tol) => tol,
             Strength::Relative(rel) => {
                 let mut mean = T::zero();
                 let mut n = T::zero();
-                for v in data {
-                    mean += **v;
+
+                // Clippy doesn't understand reborrowing and is wrong
+                #[expect(clippy::explicit_into_iter_loop)]
+                for v in data.into_iter() {
+                    mean += *v;
                     n += T::one();
                 }
                 mean /= n;
 
                 let mut std_dev = T::zero();
                 for v in data {
-                    std_dev += Value::powi(**v - mean, 2);
+                    std_dev += Value::powi(*v - mean, 2);
                 }
                 std_dev = T::sqrt(std_dev / n);
 
@@ -311,14 +317,15 @@ where
     rand_distr::Exp1: rand_distr::Distribution<T>,
     rand_distr::Open01: rand_distr::Distribution<T>,
 {
-    fn apply<'a>(&self, data: impl Iterator<Item = &'a mut T>) {
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>,
+    {
         let mut rng = Self::rng(self.seed());
         match self {
             NoiseTransform::CorrelatedGaussian { rho, strength, .. } => {
-                let data = data.collect::<Vec<_>>();
-
                 let rho = num_traits::Float::clamp(*rho, -T::one(), T::one());
-                let mut std_dev = strength.into_stddev(data.as_slice());
+                let mut std_dev = strength.into_stddev::<I>(data);
                 std_dev = Value::max(std_dev, num_traits::Float::epsilon());
                 let gaussian = Normal::new(T::zero(), std_dev)
                     .map_err(|e| e.to_string())
@@ -348,9 +355,8 @@ where
                 //
                 // Get the min and max values
                 // Relative strengths calculate bounds based on data std-dev
-                let data = data.collect::<Vec<_>>();
-                let min = min.into_stddev(data.as_slice());
-                let max = max.into_stddev(data.as_slice());
+                let min = min.into_stddev::<I>(data);
+                let max = max.into_stddev::<I>(data);
 
                 // The activation possibility
                 let flip = Bernoulli::new(probability).expect("p not in 0..1");
@@ -381,9 +387,8 @@ where
             }
 
             NoiseTransform::Uniform { upper, lower, .. } => {
-                let data = data.collect::<Vec<_>>();
-                let upper = upper.into_stddev(data.as_slice());
-                let lower = lower.into_stddev(data.as_slice());
+                let upper = upper.into_stddev::<I>(data);
+                let lower = lower.into_stddev::<I>(data);
 
                 let uniform = Uniform::new(-lower, upper)
                     .map_err(|e| e.to_string())
@@ -399,7 +404,7 @@ where
                 let lambda_abs = Value::clamp(lambda.inner(), num_traits::Float::epsilon(), l_max);
 
                 let poisson = Poisson::new(lambda_abs).expect("Invalid Poisson distribution");
-                data.for_each(|v| {
+                data.into_iter().for_each(|v| {
                     let noise = poisson.sample(&mut rng) - lambda_abs; // center around 0
                     *v += noise * lambda.into_point(*v);
                 });
@@ -722,22 +727,20 @@ where
     rand_distr::Open01: rand_distr::Distribution<T>,
 {
     fn apply_normal_noise(mut self, strength: Strength<T>, seed: Option<u64>) -> Self {
-        NoiseTransform::CorrelatedGaussian {
+        self.transform(NoiseTransform::CorrelatedGaussian {
             rho: T::zero(),
             strength,
             seed,
-        }
-        .apply(self.iter_mut().map(|(_, y)| y));
+        });
         self
     }
 
     fn apply_correlated_noise(mut self, strength: Strength<T>, rho: T, seed: Option<u64>) -> Self {
-        NoiseTransform::CorrelatedGaussian {
+        self.transform(NoiseTransform::CorrelatedGaussian {
             rho,
             strength,
             seed,
-        }
-        .apply(self.iter_mut().map(|(_, y)| y));
+        });
         self
     }
 
@@ -747,12 +750,12 @@ where
         upper: Strength<T>,
         seed: Option<u64>,
     ) -> Self {
-        NoiseTransform::Uniform { lower, upper, seed }.apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(NoiseTransform::Uniform { lower, upper, seed });
         self
     }
 
     fn apply_poisson_noise(mut self, lambda: Strength<T>, seed: Option<u64>) -> Self {
-        NoiseTransform::Poisson { lambda, seed }.apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(NoiseTransform::Poisson { lambda, seed });
         self
     }
 
@@ -763,15 +766,14 @@ where
         max: Strength<T>,
         seed: Option<u64>,
     ) -> Self {
-        NoiseTransform::Impulse {
+        self.transform(NoiseTransform::Impulse {
             probability: amount,
             alpha: T::zero(),
             beta: T::zero(),
             min,
             max,
             seed,
-        }
-        .apply(self.iter_mut().map(|(_, y)| y));
+        });
         self
     }
 
@@ -784,15 +786,14 @@ where
         beta: T,
         seed: Option<u64>,
     ) -> Self {
-        NoiseTransform::Impulse {
+        self.transform(NoiseTransform::Impulse {
             probability: amount,
             alpha,
             beta,
             min,
             max,
             seed,
-        }
-        .apply(self.iter_mut().map(|(_, y)| y));
+        });
         self
     }
 }

--- a/src/transforms/normalization.rs
+++ b/src/transforms/normalization.rs
@@ -1,6 +1,6 @@
 use crate::{
     statistics::{self, DomainNormalizer},
-    transforms::Transform,
+    transforms::{Transform, Transformable, XTransform},
     value::Value,
 };
 
@@ -140,12 +140,14 @@ pub enum NormalizationTransform<T: Value> {
 }
 
 impl<T: Value> Transform<T> for NormalizationTransform<T> {
-    fn apply<'a>(&self, data: impl Iterator<Item = &'a mut T>) {
-        let data: Vec<_> = data.collect();
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>,
+    {
         match self {
             Self::Domain { min, max } => {
                 let normalizer =
-                    DomainNormalizer::from_data(data.iter().map(|d| **d), (*min, *max))
+                    DomainNormalizer::from_data(data.into_iter().map(|d| *d), (*min, *max))
                         .unwrap_or_default();
                 for value in data {
                     *value = normalizer.normalize(*value);
@@ -159,14 +161,14 @@ impl<T: Value> Transform<T> for NormalizationTransform<T> {
             }
 
             Self::MeanSubtraction => {
-                let mean = statistics::mean(data.iter().map(|d| **d));
+                let mean = statistics::mean(data.into_iter().map(|d| *d));
                 for value in data {
                     *value -= mean;
                 }
             }
 
             Self::ZScore => {
-                let (s, m) = statistics::stddev_and_mean(data.iter().map(|d| **d));
+                let (s, m) = statistics::stddev_and_mean(data.into_iter().map(|d| *d));
                 for value in data {
                     *value = (*value - m) / s;
                 }
@@ -176,16 +178,13 @@ impl<T: Value> Transform<T> for NormalizationTransform<T> {
                 let buffer_weight =
                     asymptote_epsilon.unwrap_or_else(|| T::from(1e-2).unwrap_or(T::zero()));
 
-                if data.is_empty() {
+                let Some(asymptote) = data.into_iter().map(|d| *d).reduce(Value::max) else {
+                    // data was empty
                     return;
-                }
-
-                let asymptote = data
-                    .iter()
-                    .fold(T::neg_infinity(), |v, d| Value::max(v, **d));
+                };
 
                 // Add a small buffer to the asymptote to ensure all points are below it, which is important for the log transformation
-                let (stdev, _) = statistics::stddev_and_mean(data.iter().map(|d| **d));
+                let (stdev, _) = statistics::stddev_and_mean(data.into_iter().map(|d| *d));
                 let buffer = stdev * buffer_weight; // small fraction of typical deviation
 
                 for p in data {
@@ -355,28 +354,28 @@ pub trait ApplyNormalization<T: Value> {
 }
 impl<T: Value> ApplyNormalization<T> for Vec<(T, T)> {
     fn apply_domain_normalization(mut self, min: T, max: T) -> Self {
-        NormalizationTransform::Domain { min, max }.apply(self.iter_mut().map(|(x, _)| x));
+        let transform = NormalizationTransform::Domain { min, max };
+        XTransform(transform).apply::<Self>(&mut self);
         self
     }
 
     fn apply_clipping(mut self, min: T, max: T) -> Self {
-        NormalizationTransform::Clip { min, max }.apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(NormalizationTransform::Clip { min, max });
         self
     }
 
     fn apply_mean_subtraction(mut self) -> Self {
-        NormalizationTransform::MeanSubtraction.apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(NormalizationTransform::MeanSubtraction);
         self
     }
 
     fn apply_z_score_normalization(mut self) -> Self {
-        NormalizationTransform::ZScore.apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(NormalizationTransform::ZScore);
         self
     }
 
     fn apply_log_offset_normalization(mut self, asymptote_epsilon: Option<T>) -> Self {
-        NormalizationTransform::LogOffset { asymptote_epsilon }
-            .apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(NormalizationTransform::LogOffset { asymptote_epsilon });
         self
     }
 }
@@ -448,8 +447,11 @@ pub enum SmoothingTransform<T: Value> {
     },
 }
 impl<T: Value> Transform<T> for SmoothingTransform<T> {
-    fn apply<'a>(&self, data: impl Iterator<Item = &'a mut T>) {
-        let data: Vec<_> = data.collect();
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>,
+    {
+        let data: Vec<_> = data.into_iter().collect();
         match self {
             Self::MovingAverage { window_size } => {
                 let n = data.len();
@@ -604,12 +606,12 @@ pub trait ApplySmoothing<T: Value> {
 }
 impl<T: Value> ApplySmoothing<T> for Vec<(T, T)> {
     fn apply_moving_average_smoothing(mut self, window_size: usize) -> Self {
-        SmoothingTransform::MovingAverage { window_size }.apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(SmoothingTransform::MovingAverage { window_size });
         self
     }
 
     fn apply_gaussian_smoothing(mut self, sigma: T) -> Self {
-        SmoothingTransform::Gaussian { sigma }.apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(SmoothingTransform::Gaussian { sigma });
         self
     }
 }

--- a/src/transforms/scale.rs
+++ b/src/transforms/scale.rs
@@ -1,9 +1,21 @@
 use crate::{
-    basis::Basis, display::PolynomialDisplay, transforms::Transform, value::Value, Polynomial,
+    basis::Basis,
+    display::PolynomialDisplay,
+    transforms::{Transform, Transformable},
+    value::Value,
+    Polynomial,
 };
 
 /// Types of scaling transformations for data
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[non_exhaustive] // More may be added in future
 pub enum ScaleTransform<T: Value> {
+    /// Applies no tranformation to the dataset.
+    ///
+    /// This is only useful if you have a function which expects a `ScaleTransform`
+    /// but your data is already fine as-is without extra scaling.
+    Identity,
+
     /// Adds a fixed offset to every element of a dataset.
     ///
     /// This is useful for translating a signal up or down without changing its shape.
@@ -66,6 +78,23 @@ pub enum ScaleTransform<T: Value> {
     /// - `factor`: Multiplier applied after squaring each element.
     Quadratic(T),
 
+    /// Applies a square-root scaling to each element of a dataset.
+    ///
+    /// Each element is square-rooted and then multiplied by the specified factor.
+    ///
+    /// <div class="warning">
+    ///
+    /// **Technical Details**
+    ///
+    /// ```math
+    /// xₙ = factor * √x
+    /// ```
+    /// </div>
+    ///
+    /// # Parameters
+    /// - `factor`: Multiplier applied after square-rooting each element.
+    SquareRoot(T),
+
     /// Applies a cubic scaling to each element of a dataset.
     ///
     /// Each element is cubed and then multiplied by the specified factor.
@@ -86,6 +115,25 @@ pub enum ScaleTransform<T: Value> {
     /// - `factor`: Multiplier applied after cubing each element.
     Cubic(T),
 
+    /// Applies a cube-root scaling to each element of a dataset.
+    ///
+    /// Each element is cube-rooted and then multiplied by the specified factor.
+    ///
+    /// ![Cubic example](https://raw.githubusercontent.com/caliangroup/polyfit/refs/heads/master/.github/assets/cubic_example.png)
+    ///
+    /// <div class="warning">
+    ///
+    /// **Technical Details**
+    ///
+    /// ```math
+    /// xₙ = factor * ∛x
+    /// ```
+    /// </div>
+    ///
+    /// # Parameters
+    /// - `factor`: Multiplier applied after cubing each element.
+    CubeRoot(T),
+
     /// Applies an exponential scaling to each element of a dataset.
     ///
     /// Each element is transformed using exponentiation with the specified base
@@ -97,14 +145,13 @@ pub enum ScaleTransform<T: Value> {
     /// **Technical Details**
     ///
     /// ```math
-    /// xₙ = factor * base^x
+    /// xₙ = base^x
     /// ```
     /// </div>
     ///
     /// # Parameters
     /// - `base`: The exponent to which each element is raised.
-    /// - `factor`: The multiplier applied after exponentiation.
-    Exponential(T, T),
+    Exponential(T),
 
     /// Applies a logarithmic scaling to each element of a dataset.
     ///
@@ -116,43 +163,110 @@ pub enum ScaleTransform<T: Value> {
     ///
     /// # Parameters
     /// - `base`: The base of the logarithm.
-    /// - `factor`: The multiplier applied after logarithmic transformation.
-    Logarithmic(T, T),
+    Logarithmic(T),
 }
 impl<T: Value> Transform<T> for ScaleTransform<T> {
-    fn apply<'a>(&self, data: impl Iterator<Item = &'a mut T>) {
-        match self {
+    fn apply<I: ?Sized>(&self, data: &mut I)
+    where
+        for<'a> &'a mut I: IntoIterator<Item = &'a mut T>,
+    {
+        match *self {
+            ScaleTransform::Identity => {}
             ScaleTransform::Shift(amount) => {
                 for value in data {
-                    *value += *amount;
+                    *value += amount;
                 }
             }
             ScaleTransform::Linear(slope) => {
                 for value in data {
-                    *value *= *slope;
+                    *value *= slope;
                 }
             }
             ScaleTransform::Quadratic(coef) => {
                 for value in data {
-                    *value = *value * *value * *coef;
+                    *value = *value * *value * coef;
+                }
+            }
+            ScaleTransform::SquareRoot(coef) => {
+                for value in data {
+                    *value = value.sqrt() * coef;
                 }
             }
             ScaleTransform::Cubic(coef) => {
                 for value in data {
-                    *value = *value * *value * *value * *coef;
+                    *value = *value * *value * *value * coef;
                 }
             }
-            ScaleTransform::Exponential(base, coef) => {
+            ScaleTransform::CubeRoot(coef) => {
                 for value in data {
-                    *value = base.powf(*value) * *coef;
+                    *value = value.cbrt() * coef;
                 }
             }
-            ScaleTransform::Logarithmic(base, coef) => {
+            ScaleTransform::Exponential(base) => {
                 for value in data {
-                    *value = Value::max(*value, T::epsilon()).log(*base) * *coef;
+                    *value = base.powf(*value);
+                }
+            }
+            ScaleTransform::Logarithmic(base) => {
+                for value in data {
+                    *value = Value::max(*value, T::min_positive_value()).log(base);
                 }
             }
         }
+    }
+}
+
+impl<T: Value> ScaleTransform<T> {
+    /// Returns the inverse transform that will undo this transform.
+    ///
+    /// For example, `ScaleTransform::Shift(10).inverse()` gives `ScaleTransform::Shift(-1)`,
+    /// and `ScaleTransform::Linear(0.25).inverse()` gives `ScaleTransform::Linear(4.0)`.
+    #[must_use]
+    pub fn inverse(self) -> Self {
+        // I hate pedantic lints; there's nothing wrong with this inside a function.
+        #![expect(clippy::enum_glob_use)]
+        use ScaleTransform::*;
+        match self {
+            Identity => Identity,
+            Shift(amount) => Shift(-amount),
+            Linear(slope) => Linear(T::one() / slope),
+            Quadratic(coef) => SquareRoot(T::one() / coef.sqrt()),
+            SquareRoot(coef) => Quadratic(T::one() / (coef * coef)),
+            Cubic(coef) => CubeRoot(T::one() / coef.cbrt()),
+            CubeRoot(coef) => Cubic(T::one() / (coef * coef * coef)),
+            Exponential(base) => Logarithmic(base),
+            Logarithmic(base) => Exponential(base),
+        }
+    }
+
+    /// Returns the sequence of transformations that will undo
+    /// the sequence of tranformations in `array`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use polyfit::transforms::{ScaleTransform, Transform, Transformable};
+    ///
+    /// let celcius_to_fahrenheit = [
+    ///     ScaleTransform::Linear(9.0 / 5.0),
+    ///     ScaleTransform::Shift(32.0),
+    /// ];
+    /// let known_c = [-40.0, 0.0, 100.0];
+    /// let equivalent_f = known_c.transformed(&celcius_to_fahrenheit);
+    /// assert_eq!(equivalent_f, [-40.0, 32.0, 212.0]);
+    ///
+    /// let fahrenheit_to_celcius = ScaleTransform::inverse_array(celcius_to_fahrenheit);
+    /// assert!(matches!(
+    ///     fahrenheit_to_celcius,
+    ///     [ScaleTransform::Shift(_), ScaleTransform::Linear(_)],
+    /// ));
+    /// let mut x = 32.0;
+    /// fahrenheit_to_celcius.apply_to(&mut x);
+    /// assert_eq!(x, 0.0);
+    /// ```
+    #[must_use]
+    pub fn inverse_array<const N: usize>(array: [Self; N]) -> [Self; N] {
+        std::array::from_fn(move |i| array[N - 1 - i].inverse())
     }
 }
 
@@ -342,27 +456,30 @@ pub trait ApplyScale<T: Value> {
 }
 impl<T: Value> ApplyScale<T> for Vec<(T, T)> {
     fn apply_shift_scale(mut self, amount: T) -> Self {
-        ScaleTransform::Shift(amount).apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(ScaleTransform::Shift(amount));
         self
     }
 
     fn apply_linear_scale(mut self, factor: T) -> Self {
-        ScaleTransform::Linear(factor).apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(ScaleTransform::Linear(factor));
         self
     }
 
     fn apply_quadratic_scale(mut self, coef: T) -> Self {
-        ScaleTransform::Quadratic(coef).apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(ScaleTransform::Quadratic(coef));
         self
     }
 
     fn apply_cubic_scale(mut self, coef: T) -> Self {
-        ScaleTransform::Cubic(coef).apply(self.iter_mut().map(|(_, y)| y));
+        self.transform(ScaleTransform::Cubic(coef));
         self
     }
 
-    fn apply_exponential_scale(mut self, degree: T, factor: T) -> Self {
-        ScaleTransform::Exponential(degree, factor).apply(self.iter_mut().map(|(_, y)| y));
+    fn apply_exponential_scale(mut self, base: T, factor: T) -> Self {
+        self.transform([
+            ScaleTransform::Exponential(base),
+            ScaleTransform::Linear(factor),
+        ]);
         self
     }
 
@@ -379,14 +496,48 @@ impl<T: Value> ApplyScale<T> for Vec<(T, T)> {
     }
 
     fn apply_logarithmic_scale(mut self, base: T, factor: T) -> Self {
-        ScaleTransform::Logarithmic(base, factor).apply(self.iter_mut().map(|(_, y)| y));
+        self.transform([
+            ScaleTransform::Logarithmic(base),
+            ScaleTransform::Linear(factor),
+        ]);
         self
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::transforms::ApplyScale;
+    use crate::assert_close;
+
+    use super::*;
+
+    #[test]
+    fn test_inverse() {
+        use ScaleTransform::*;
+        let pairs = [
+            (Identity, Identity),
+            (Shift(7.0), Shift(-7.0)),
+            (Linear(8.0), Linear(0.125)),
+            (Quadratic(0.25), SquareRoot(2.0)),
+            (Cubic(0.125), CubeRoot(2.0)),
+            (Exponential(3.0), Logarithmic(3.0)),
+        ];
+        for (a, b) in pairs {
+            assert_eq!(a.inverse(), b);
+            assert_eq!(a, b.inverse());
+
+            let expected = 12.34;
+
+            let mut x = expected;
+            a.apply_to(&mut x);
+            b.apply_to(&mut x);
+            assert_close!(x, expected, epsilon = 1.0e-12);
+
+            let mut x = expected;
+            b.apply_to(&mut x);
+            a.apply_to(&mut x);
+            assert_close!(x, expected, epsilon = 1.0e-12);
+        }
+    }
 
     #[test]
     fn test_shift_scale() {


### PR DESCRIPTION
Opening this probably more as a discussion, because while I started trying to do something simple, I ended up way down a rabbit hole and this is really bigger than probably makes sense to land as one thing, but figured I'd open it with all the stuff and we can chat about whether you even want all these changes and how to split them into smaller steps.

---

I started just trying to make a `ScaleTransform::inverse` method, because after scaling the inputs to something I often wanted to un-scale the outputs, and I'm really good at getting that inverse wrong.

That required two changes:
- Adding ∛ and √ transforms, which seem reasonable enough.  (I also stuck `non_exhaustive` on the enum so more can be added later without another semver break.)
- Figuring out what to do about `ScaleTransform::Exponential`, because its multiplicative factor *can't* be undone by `Logarithmic`'s factor.  (And, correspondingly, that `ScaleTransform::Logarithmic`'s factor is kinda weird since it could always be collapsed into the base.)

So the first possibly-controversial change: I removed the factors from `Exponential` and `Logarithmic`.  TBH, I find that kinda reasonable anyway, because I always thought that `(T, T)` was quite unclear for exactly what they were doing, whereas with just one `T` it's obvious.  (An alternative here would be to move to something like `Exponential { base: T, factor: T, phase: T` for x' = factor * pow(base, x - phase), but that felt kinda like overkill.)  I also like that that makes the size of the variants more consistent.

To make sure that that was still possible, I had the idea that ended up being the cause of all my problems: let people put transforms in an array to compose them so that we don't need all the pre-composed versions.  That way the migration path from `ScaleTransform::Exponential(b, f)` is to `[ScaleTransform::Exponential(b), ScaleTransform::Linear(f)]`.  And it also opens the door to affine transformations by combining `Linear`+`Shift`, etc.  (See the example on `inverse_array` for a worked version of this.)

At first that went great, but then I realized that trying to use `Transform::apply_to` doesn't work at all for all the impure transformations.  (I'd tried implementing `apply` by calling each transform's `apply_to` on each element, which is great for `ScaleTransform` but totally nonsensical for the smoothing ones and such.)

Thus the giant scary change here: **letting `Transform::apply` iterate multiple times**.

That definitely comes at a cost, because the signature needs to change from the easy `impl Iterator<Item = &mut T>` to the more complicated `for<'a> &'a mut I: IntoIterator<Item = &'a mut T>`.  The compiler definitely isn't as comfortable dealing with ∀'a bounds as it is for more "normal" things.  If it was just for this array case, that wouldn't be worth it at all.

But one cool consequence of it is that **a bunch of transforms no longer allocate!**  For example, `MeanSubtraction` can now iterate once to get the mean, then iterate again to subtract it.  `Strength::into_stddev` no longer needs a slice, so its callers -- such as `NoiseTransform::CorrelatedGaussian` -- don't have to allocate.  No more collecting into a `Vec<&mut T>`.  And it's all still safe code, too.

So that seems overall at least plausible, since so long as one normally goes through `Transformable` anyway you don't even see the difference; things just work better under the hood.  And thus this PR 🙂 

---

A few other notes of things I did along the way:

- Added `XTransform` and `YTransform` wrappers to adapt transforms from working on a scalar to working on a component of a pair.
- Changed `Transformable` to taking a `impl Transform` instead of `&impl Transform`, but then adding a blanket `impl<R: Transform> Transform for &R` so that passing a reference to an `impl Transform` still works.
- Switched `ScaleTransform::Logarithmic` to use `T::min_positive_value()` instead of `T::epsilon()` because there are a *ton* of floats smaller that `epsilon`.  (For `f64`, ε is about 2e-16 and min_positive is about 2e-308.)
- Removed the `Self: Sized` bound on `Transformable::transformed` so you can do things like `array[i..j].transformed(…)` (applying it to a slice) and it uses `ToOwned` to get you a `Vec` result.
