### PR TITLE
Add rational P(x)/Q(x) fitting + 4 rough-edge fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,4 +5,4 @@ Version     Date        Changes
 0.10.0      22/01/26    https://github.com/rscarson/polyfit/releases/tag/0.10.0
 0.10.1      23/01/26    https://github.com/rscarson/polyfit/releases/tag/0.10.1
 0.10.2      28/01/26    https://github.com/rscarson/polyfit/releases/tag/0.10.2
-0.11.0      --/--/--    Pending issues #3, #4, #9 and #10 
+0.11.0      --/--/--    Pending issues #3, #4, #9 and #10

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,153 @@
+# rational module — shortfalls and TODO
+
+A record of what works, what's weak, and what remains. Written 2026-04-14
+after a devil's-advocate review of the first deployment (linear-srgb PR #8).
+
+## What ships
+
+- **SK → LM pipeline** with analytical Jacobian, Nielsen damping, deterministic
+  multi-restart (sin/cos phases, no RNG).
+- **`optimize_f32`** — truncate-to-f32 then local coordinate-descent ULP search.
+  Supports exhaustive f32 sweep or uniform sampling via `F32SearchConfig.samples`.
+- **`refine_from_f32`** — warm-start LM from existing f32 coefficients.
+- **`piecewise_gap`** — measures ULP gap between a linear branch and the
+  polynomial at their join. Distinct from `boundary_ulp` (poly-vs-reference).
+- **`measure_roundtrip`** — composed `f⁻¹(f(v))` error with u8/u16 step counts.
+- **`F32SearchResult.exhaustive` + `values_scored`** — callers can tell the
+  measurement regime at a glance.
+- **Self-consistency test** — guards against scorer/measurement drift.
+- **Absolute error scoring** (`F32ScoreMetric::AbsoluteError`) — for output-
+  crosses-zero functions where ULP is misleading (log2 near mantissa=1).
+
+Deployed once so far: linear-srgb base 4/4 S2L/L2S coefficients (PR #8, still
+under review). EXT_L2S 6/6 previously landed via a separate iteration in that
+crate's PR #6.
+
+## Known shortfalls
+
+### 1. f32 search isn't peerless against hand-tuned coefficients
+
+log2 mantissa (libjxl, 3/3 rational on [−0.33, 0.33]):
+
+| source | max_abs_err |
+|---|---|
+| libjxl | 4.53e-6 |
+| polyfit fresh fit | 6.08e-6 (34% worse) |
+| polyfit warm-start LM | diverged |
+
+libjxl's coefficients are tuned for absolute error near zero specifically;
+polyfit's Chebyshev-node fit overweights the domain edges. We don't currently
+have a way to weight the residuals by *region* — only by the global
+ULP / absolute / relative metric.
+
+### 2. Warm-start LM diverges from f32 coefficients for tight fits
+
+`refine_from_f32` promotes f32 → f64, runs LM. For very well-tuned starting
+points (PQ inverse small, log2 lowp) the f32 rounding produces a residual
+structure LM chases into a much worse basin. Current mitigation: try both
+fresh and warm-start, keep the better. No root-cause fix.
+
+### 3. Joint (multi-polynomial) optimization is ad-hoc
+
+For roundtrip-sensitive functions (S2L + L2S) the individual-fit optimum is
+not the composed-optimum. The example `joint_roundtrip.rs` shows marginal
+improvement (rt_fwd 16→15, rt_inv 26→24 ULP) after brute-force coordinate
+descent on 13 coefficients. There's no library API for "jointly optimize
+two rationals with a user-supplied composite objective."
+
+### 4. Constraint modes are tricky
+
+- `SnapOnly` works for boundary x near zero (small p[0] perturbation).
+- `Both` with high weight destabilizes LM (constraint dominates J^T J).
+- `SkThenSnap` pulls SK into a worse basin that LM can't recover from.
+
+Callers currently have to try several modes + weights and pick by outcome.
+This is the cherry-picking risk the devil's advocate flagged. No principled
+weight-selection heuristic.
+
+### 5. Extended-range wide-domain fits are slow
+
+Exhaustive f32 sweep on [0.003, 1.0] after sqrt transform is ~70M points.
+`optimize_f32` with exhaustive mode + 13 coefficients × 6 deltas × 5 rounds
+takes minutes per fit. Sampled mode (`samples: Some(N)`) is the practical
+workaround but may miss the true worst-case f32 value. No early-termination
+once a clear winner is found.
+
+### 6. No cross-architecture validation
+
+All measurements were done on x86-64 with FMA. `mul_add` in the Horner loops
+goes through `num_traits::Float` → libm software fallback on non-FMA targets
+with different rounding. polyfit doesn't spot-check aarch64 / wasm32
+behavior. The linear-srgb PR inherited this hole: the "perfect monotonicity"
+claim is untested outside x86-64.
+
+### 7. F32 coefficient printing is caller's problem
+
+`{c:.10e}` on an f32 prints 10 digits when only ~7 are representable. The
+*stored* value is correct (f32), but pasted into source looks like it has
+more precision than it does — triggering `#[allow(clippy::excessive_precision)]`
+downstream. No helper that formats f32 at minimum-sufficient precision.
+
+### 8. No "fit script committed alongside output" pattern enforced
+
+polyfit provides the fitter; users write their own scripts calling it. There's
+nothing stopping a caller from running many restart/weight combinations,
+keeping the best, and shipping the coefficients without the recipe. The
+linear-srgb PR #8 has exactly this problem — coefficients land in source,
+the generator stays in another repo.
+
+## TODO
+
+- [ ] **Region-weighted residuals** — let callers specify `w(x)` in the fit
+      objective so log2-mantissa-near-zero stays competitive with libjxl
+- [ ] **`optimize_pair`** — library API for joint multi-polynomial optimization
+      with user-supplied composite objective; generalize
+      `examples/joint_roundtrip.rs`
+- [ ] **Diagnostic on warm-start divergence** — `refine_from_f32` should
+      return both original and refined metrics so callers can reject
+      regressions (currently returns only the refined result)
+- [ ] **Constraint-aware LM damping** — scale λ by the data residual only,
+      not by constraint rows. Would make `ConstraintMode::Both` with high
+      weights actually usable.
+- [ ] **`F32SearchConfig.radius` auto-tuning** — start narrow, widen if no
+      improvement; currently fixed at 3 ULP/coeff which misses larger
+      basins for tight fits
+- [ ] **Parallel restart evaluation** behind a feature flag — 4–8 restarts
+      are cheap individually, embarrassingly parallel
+- [ ] **f32 coefficient formatter** — `fmt_f32_min_precision(v)` returning a
+      string that parses back to the exact same f32 bits with minimum digits
+- [ ] **Architecture crosscheck helper** — `measure_roundtrip` variant that
+      runs the same sweep with libm's `fmaf` emulation vs native FMA,
+      reports divergence
+- [ ] **CHANGELOG + fitter-script-in-repo template** — document the
+      expected pattern: fit script lives next to the coefficients it produces,
+      with seed/inputs pinned
+- [ ] **Nielsen damping parameter exposure** — LM currently hardcodes
+      `τ=1e-3`, `ν₀=2`. Callers with pathological fits may want to tune.
+- [ ] **Better scoring for near-zero outputs** — current ULP metric reports
+      billions for log2 mantissa = 0 crossings. The `AbsoluteError` metric
+      exists but its interaction with `F32SearchConfig` isn't unified across
+      scoring and final-measurement paths
+- [ ] **Exhaustive sweep speedup** — SIMD the Horner eval in `f32_local_search`.
+      Currently scalar; a 4× / 8× speedup would move wide-domain exhaustive
+      sweeps from minutes to seconds
+
+## Non-goals / deliberate omissions
+
+- **General nonlinear optimization** — polyfit isn't scipy; stick to
+  rational polynomial fits
+- **Symbolic simplification** — we return numeric coefficients, not
+  factored forms
+- **Rational function root finding** — users can call `Polynomial::roots`
+  on the numerator/denominator separately if they need this
+- **`no_std`** — nalgebra needs std; we inherit that constraint
+
+## Devil's-advocate findings NOT yet addressed
+
+From the review of linear-srgb PR #8 specifically:
+- `#[allow(clippy::excessive_precision)]` spreading — needs #7 above
+- Fitter-script-not-committed in the target repo — needs #9 above
+- No aarch64 / wasm32 validation — needs the architecture crosscheck helper
+- README drift in downstream crates — that's a caller discipline issue,
+  but polyfit could output the accuracy table in a copy-pasteable format
+  so callers are less tempted to skip updating docs

--- a/examples/apply_linear_srgb.rs
+++ b/examples/apply_linear_srgb.rs
@@ -1,0 +1,279 @@
+//! Generate a specific set of optimal linear-srgb coefficients with
+//! manually-chosen tradeoffs, and validate with exhaustive f32 sweeps.
+
+use polyfit::rational::{
+    Constraint, ConstraintMode, ErrorWeighting, F32SearchConfig, RationalFit, RationalFitOptions,
+    RationalPolynomial,
+};
+
+const A: f64 = 0.055_010_718_947_586_6;
+const A1: f64 = 1.0 + A;
+const THRESHOLD_LINEAR: f64 = 0.003_041_282_560_127_521;
+const THRESHOLD_GAMMA: f64 = 12.92 * THRESHOLD_LINEAR;
+
+fn ref_s2l(v: f64) -> f64 {
+    if v <= THRESHOLD_GAMMA {
+        v / 12.92
+    } else {
+        ((v + A) / A1).powf(2.4)
+    }
+}
+fn ref_l2s(v: f64) -> f64 {
+    if v <= THRESHOLD_LINEAR {
+        v * 12.92
+    } else {
+        A1 * v.powf(1.0 / 2.4) - A
+    }
+}
+
+fn chebyshev_data(f: impl Fn(f64) -> f64, lo: f64, hi: f64, n: usize) -> Vec<(f64, f64)> {
+    let pi = std::f64::consts::PI;
+    (0..n)
+        .map(|k| {
+            let theta = pi * (2.0 * k as f64 + 1.0) / (2.0 * n as f64);
+            let x = (lo + hi) / 2.0 + (hi - lo) / 2.0 * theta.cos();
+            (x, f(x))
+        })
+        .collect()
+}
+
+fn print_const(name: &str, coeffs: &[f32], doc: &str) {
+    if !doc.is_empty() {
+        println!("/// {doc}");
+    }
+    println!("pub(crate) const {name}: [f32; {}] = [", coeffs.len());
+    for (i, &c) in coeffs.iter().enumerate() {
+        let comma = if i + 1 < coeffs.len() { "," } else { "" };
+        println!("    {c:.10e}{comma}");
+    }
+    println!("];");
+}
+
+fn main() {
+    let sampled_cfg = F32SearchConfig {
+        samples: Some(500_000),
+        ..F32SearchConfig::default()
+    };
+    let _ = sampled_cfg.clone();
+
+    // ==================================================================
+    // S2L 4/4: try several weights, pick best max_ulp with bnd ≤ 1
+    // ==================================================================
+    println!("--- S2L 4/4 ---");
+    let mut best_s2l: Option<polyfit::rational::F32SearchResult> = None;
+    for &weight in &[50_000.0, 100_000.0, 300_000.0, 1_000_000.0] {
+        let s2l_opt = RationalFitOptions {
+            weighting: ErrorWeighting::Relative,
+            n_samples: 20_000,
+            restarts: 8,
+            constraints: vec![Constraint::with_weight(
+                THRESHOLD_GAMMA,
+                THRESHOLD_LINEAR,
+                weight,
+            )],
+            constraint_mode: ConstraintMode::Both,
+            ..RationalFitOptions::default()
+        };
+        let s2l_fit = RationalFit::from_function(
+            |v| ((v + A) / A1).powf(2.4),
+            THRESHOLD_GAMMA..=1.0,
+            4,
+            4,
+            s2l_opt,
+        )
+        .unwrap();
+        let s2l = s2l_fit.as_polynomial().optimize_f32(
+            ref_s2l,
+            THRESHOLD_GAMMA as f32,
+            1.0,
+            |v| v,
+            sampled_cfg.clone(),
+        );
+        println!("S2L w={weight:>8.0}: {s2l}");
+        if s2l.boundary_ulp <= 1 && s2l.mono_violations == 0 {
+            best_s2l = Some(match best_s2l {
+                None => s2l,
+                Some(best) => {
+                    if s2l.max_ulp < best.max_ulp {
+                        s2l
+                    } else {
+                        best
+                    }
+                }
+            });
+        }
+    }
+    let s2l = best_s2l.expect("no S2L candidate with bnd <= 1");
+    println!("Selected S2L: {s2l}");
+
+    // ==================================================================
+    // L2S 4/4: weighted constraint w=1000 for bnd=0
+    // ==================================================================
+    println!("\n--- L2S 4/4 ---");
+    let l2s_opt = RationalFitOptions {
+        weighting: ErrorWeighting::Relative,
+        n_samples: 20_000,
+        restarts: 8,
+        constraints: vec![Constraint::with_weight(
+            THRESHOLD_LINEAR.sqrt(),
+            THRESHOLD_GAMMA,
+            1000.0,
+        )],
+        constraint_mode: ConstraintMode::Both,
+        ..RationalFitOptions::default()
+    };
+    let l2s_fit = RationalFit::from_function(
+        |s| A1 * (s * s).powf(1.0 / 2.4) - A,
+        THRESHOLD_LINEAR.sqrt()..=1.0,
+        4,
+        4,
+        l2s_opt,
+    )
+    .unwrap();
+    let l2s = l2s_fit.as_polynomial().optimize_f32(
+        ref_l2s,
+        THRESHOLD_LINEAR as f32,
+        1.0,
+        |v| v.sqrt(),
+        sampled_cfg.clone(),
+    );
+    println!("L2S 4/4 (w=1000 + exhaustive search): {l2s}");
+
+    // ==================================================================
+    // EXT_L2S 6/6: warm-start from current, then f32 search
+    // ==================================================================
+    println!("\n--- EXT_L2S 6/6 ---");
+    let current_ext_l2s_p: [f32; 7] = [
+        -1.025_467_4,
+        -3.075_361_5e-1,
+        1.027_286e3,
+        7.093_665e3,
+        1.006_868_9e4,
+        3.230_716e3,
+        1.769_130_4e2,
+    ];
+    let current_ext_l2s_q: [f32; 7] = [
+        1.977_460_5e1,
+        8.308_271e2,
+        6.024_792_5e3,
+        1.024_407_5e4,
+        4.157_534e3,
+        3.179_324_6e2,
+        1.0,
+    ];
+    let l2s_ext_data = chebyshev_data(
+        |s| A1 * (s * s).powf(1.0 / 2.4) - A,
+        THRESHOLD_LINEAR.sqrt(),
+        8.0,
+        10_000,
+    );
+    let ext_l2s = RationalPolynomial::<f64>::refine_from_f32(
+        &current_ext_l2s_p,
+        &current_ext_l2s_q,
+        ref_l2s,
+        &l2s_ext_data,
+        THRESHOLD_LINEAR as f32,
+        1.0,
+        |v| v.sqrt(),
+        sampled_cfg.clone(),
+        ErrorWeighting::Relative,
+        300,
+    );
+    println!("EXT_L2S 6/6 (warm-start + exhaustive): {ext_l2s}");
+
+    // ==================================================================
+    // EXT_S2L 6/6: keep current (sampled found max=5 bnd=2, current exhaustive is max=6 bnd=0)
+    // But let's also try a fresh warm-start
+    // ==================================================================
+    println!("\n--- EXT_S2L 6/6 ---");
+    let current_ext_s2l_p: [f32; 7] = [
+        1.802_136_5e1,
+        9.110_411_4e2,
+        1.570_602_1e4,
+        1.020_638_2e5,
+        2.199_931_2e5,
+        1.338_269_2e5,
+        1.706_519_4e4,
+    ];
+    let current_ext_s2l_q: [f32; 7] = [
+        2.159_401_7e4,
+        1.508_555_1e5,
+        2.303_299_0e5,
+        8.239_410_8e4,
+        4.473_249_1e3,
+        -6.359_000_1e1,
+        1.0,
+    ];
+    let s2l_ext_data = chebyshev_data(|v| ((v + A) / A1).powf(2.4), THRESHOLD_GAMMA, 8.0, 10_000);
+    // Warm-start preserves boundary better than fresh fit for 6/6
+    let ext_s2l = RationalPolynomial::<f64>::refine_from_f32(
+        &current_ext_s2l_p,
+        &current_ext_s2l_q,
+        ref_s2l,
+        &s2l_ext_data,
+        THRESHOLD_GAMMA as f32,
+        1.0,
+        |v| v,
+        sampled_cfg,
+        ErrorWeighting::Relative,
+        300,
+    );
+    println!("EXT_S2L 6/6 (warm-start + sampled): {ext_s2l}");
+
+    // Final coefficients
+    println!("\n{}", "=".repeat(70));
+    println!("  APPLY TO linear-srgb/src/rational_poly.rs");
+    println!("{}\n", "=".repeat(70));
+
+    print_const(
+        "S2L_P",
+        &s2l.numerator,
+        &format!(
+            "sRGB EOTF numerator. Max {} ULP, boundary {} ULP.",
+            s2l.max_ulp, s2l.boundary_ulp
+        ),
+    );
+    print_const("S2L_Q", &s2l.denominator, "sRGB EOTF denominator.");
+    println!();
+    print_const(
+        "L2S_P",
+        &l2s.numerator,
+        &format!(
+            "sRGB inv EOTF numerator on √x. Max {} ULP, boundary {} ULP.",
+            l2s.max_ulp, l2s.boundary_ulp
+        ),
+    );
+    print_const(
+        "L2S_Q",
+        &l2s.denominator,
+        "sRGB inv EOTF denominator on √x.",
+    );
+    println!();
+    print_const(
+        "EXT_S2L_P",
+        &ext_s2l.numerator,
+        &format!(
+            "Extended sRGB EOTF numerator [0, 8]. Max {} ULP in [0,1], boundary {} ULP.",
+            ext_s2l.max_ulp, ext_s2l.boundary_ulp
+        ),
+    );
+    print_const(
+        "EXT_S2L_Q",
+        &ext_s2l.denominator,
+        "Extended sRGB EOTF denominator [0, 8].",
+    );
+    println!();
+    print_const(
+        "EXT_L2S_P",
+        &ext_l2s.numerator,
+        &format!(
+            "Extended sRGB inv EOTF numerator on √x [0, 64]. Max {} ULP in [0,1], boundary {} ULP.",
+            ext_l2s.max_ulp, ext_l2s.boundary_ulp
+        ),
+    );
+    print_const(
+        "EXT_L2S_Q",
+        &ext_l2s.denominator,
+        "Extended sRGB inv EOTF denominator on √x [0, 64].",
+    );
+}

--- a/examples/generate_linear_srgb.rs
+++ b/examples/generate_linear_srgb.rs
@@ -1,0 +1,361 @@
+//! Generate optimized sRGB rational polynomial coefficients for linear-srgb.
+//!
+//! Output format: ready to paste into src/rational_poly.rs
+//!
+//! For each polynomial, tries multiple strategies and prints the best:
+//!   - Unconstrained fit (best accuracy, ignores boundary)
+//!   - SnapOnly (unconstrained fit + post-hoc boundary adjustment on p[0])
+//!   - Weighted constraint (moderate weight, balances both)
+//!   - Warm-start LM from current coefficients
+//!
+//! Run: cargo run --release --example generate_linear_srgb
+
+use polyfit::rational::{
+    Constraint, ConstraintMode, ErrorWeighting, F32SearchConfig, F32SearchResult, RationalFit,
+    RationalFitOptions, RationalPolynomial,
+};
+
+const A: f64 = 0.055_010_718_947_586_6;
+const A1: f64 = 1.0 + A;
+const THRESHOLD_LINEAR: f64 = 0.003_041_282_560_127_521;
+const THRESHOLD_GAMMA: f64 = 12.92 * THRESHOLD_LINEAR;
+
+fn ref_s2l(v: f64) -> f64 {
+    if v <= THRESHOLD_GAMMA {
+        v / 12.92
+    } else {
+        ((v + A) / A1).powf(2.4)
+    }
+}
+fn ref_l2s(v: f64) -> f64 {
+    if v <= THRESHOLD_LINEAR {
+        v * 12.92
+    } else {
+        A1 * v.powf(1.0 / 2.4) - A
+    }
+}
+
+fn chebyshev_data(f: impl Fn(f64) -> f64, lo: f64, hi: f64, n: usize) -> Vec<(f64, f64)> {
+    let pi = std::f64::consts::PI;
+    (0..n)
+        .map(|k| {
+            let theta = pi * (2.0 * k as f64 + 1.0) / (2.0 * n as f64);
+            let x = (lo + hi) / 2.0 + (hi - lo) / 2.0 * theta.cos();
+            (x, f(x))
+        })
+        .collect()
+}
+
+fn find_best(
+    label: &str,
+    fit_fn: impl Fn(f64) -> f64 + Copy,
+    domain_lo: f64,
+    domain_hi: f64,
+    p_deg: usize,
+    q_deg: usize,
+    reference: impl Fn(f64) -> f64 + Copy,
+    sweep_lo: f32,
+    sweep_hi: f32,
+    transform: impl Fn(f32) -> f32 + Copy,
+    transform_f64: impl Fn(f64) -> f64 + Copy,
+    boundary: (f64, f64),
+    current_p: &[f32],
+    current_q: &[f32],
+) -> F32SearchResult {
+    println!("\n{}", "=".repeat(70));
+    println!("  {label}");
+    println!("{}\n", "=".repeat(70));
+
+    // Use sampled mode (500K uniform samples) — much faster than exhaustive f32 sweep,
+    // and we validate with a real exhaustive sweep at the end.
+    let cfg = F32SearchConfig {
+        samples: Some(500_000),
+        ..F32SearchConfig::default()
+    };
+
+    let mut candidates: Vec<(String, F32SearchResult)> = Vec::new();
+
+    // Current baseline
+    let cur_poly = RationalPolynomial::new(
+        current_p.iter().map(|&c| f64::from(c)).collect(),
+        current_q.iter().map(|&c| f64::from(c)).collect(),
+    );
+    let cur = cur_poly.optimize_f32(reference, sweep_lo, sweep_hi, transform, cfg.clone());
+    println!(
+        "Current (no search): max={} bnd={} avg={:.3} mono={}",
+        cur.max_ulp, cur.boundary_ulp, cur.avg_ulp, cur.mono_violations
+    );
+    candidates.push(("current       ".to_string(), cur));
+
+    // Strategy 1: Unconstrained
+    {
+        let opt = RationalFitOptions {
+            weighting: ErrorWeighting::Relative,
+            n_samples: 10_000,
+            restarts: 4,
+            ..RationalFitOptions::default()
+        };
+        let fit =
+            RationalFit::from_function(fit_fn, domain_lo..=domain_hi, p_deg, q_deg, opt).unwrap();
+        let r =
+            fit.as_polynomial()
+                .optimize_f32(reference, sweep_lo, sweep_hi, transform, cfg.clone());
+        println!("Unconstrained:       {r}");
+        candidates.push(("unconstrained ".to_string(), r));
+    }
+
+    // Strategy 2: SnapOnly (nails boundary=0 or 1 via p[0] adjustment)
+    {
+        let opt = RationalFitOptions {
+            weighting: ErrorWeighting::Relative,
+            n_samples: 10_000,
+            restarts: 4,
+            constraints: vec![Constraint::new(boundary.0, boundary.1)],
+            constraint_mode: ConstraintMode::SnapOnly,
+            ..RationalFitOptions::default()
+        };
+        let fit =
+            RationalFit::from_function(fit_fn, domain_lo..=domain_hi, p_deg, q_deg, opt).unwrap();
+        let r =
+            fit.as_polynomial()
+                .optimize_f32(reference, sweep_lo, sweep_hi, transform, cfg.clone());
+        println!("SnapOnly:            {r}");
+        candidates.push(("snap_only     ".to_string(), r));
+    }
+
+    // Strategy 3: Weighted constraint (moderate)
+    for &weight in &[100.0, 1000.0, 10000.0] {
+        let opt = RationalFitOptions {
+            weighting: ErrorWeighting::Relative,
+            n_samples: 10_000,
+            restarts: 4,
+            constraints: vec![Constraint::with_weight(boundary.0, boundary.1, weight)],
+            constraint_mode: ConstraintMode::Both,
+            ..RationalFitOptions::default()
+        };
+        let fit =
+            RationalFit::from_function(fit_fn, domain_lo..=domain_hi, p_deg, q_deg, opt).unwrap();
+        let r =
+            fit.as_polynomial()
+                .optimize_f32(reference, sweep_lo, sweep_hi, transform, cfg.clone());
+        println!("Weighted w={weight:>6.0}:    {r}");
+        candidates.push((format!("weighted_{weight:.0}    "), r));
+    }
+
+    // Strategy 4: Warm-start LM from current
+    {
+        let data = chebyshev_data(fit_fn, domain_lo, domain_hi, 10_000);
+        let r = RationalPolynomial::<f64>::refine_from_f32(
+            current_p,
+            current_q,
+            reference,
+            &data,
+            sweep_lo,
+            sweep_hi,
+            transform,
+            cfg.clone(),
+            ErrorWeighting::Relative,
+            300,
+        );
+        println!("Warm-start LM:       {r}");
+        candidates.push(("warm_start    ".to_string(), r));
+    }
+
+    // Suppress unused warning
+    let _ = transform_f64;
+
+    // Pick best by (max_ulp ascending, then boundary_ulp ascending, then avg_ulp)
+    let best_idx = candidates
+        .iter()
+        .enumerate()
+        .filter(|(_, (_, r))| r.mono_violations == 0)
+        .min_by(|a, b| {
+            let ar = &a.1 .1;
+            let br = &b.1 .1;
+            (ar.max_ulp, ar.boundary_ulp)
+                .cmp(&(br.max_ulp, br.boundary_ulp))
+                .then(ar.avg_ulp.partial_cmp(&br.avg_ulp).unwrap())
+        })
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+
+    let (best_label, best) = &candidates[best_idx];
+    println!("\n>>> Best strategy: {}", best_label.trim());
+    println!(">>> {}", best);
+    best.clone()
+}
+
+fn print_coeffs(name: &str, coeffs: &[f32], comment: &str) {
+    if !comment.is_empty() {
+        println!("/// {comment}");
+    }
+    println!("pub(crate) const {name}: [f32; {}] = [", coeffs.len());
+    for (i, &c) in coeffs.iter().enumerate() {
+        let comma = if i + 1 < coeffs.len() { "," } else { "" };
+        println!("    {c:.10e}{comma}");
+    }
+    println!("];");
+}
+
+fn main() {
+    // S2L 4/4
+    let s2l = find_best(
+        "S2L 4/4 (base clamped path, [0, 1])",
+        |v| ((v + A) / A1).powf(2.4),
+        THRESHOLD_GAMMA,
+        1.0,
+        4,
+        4,
+        ref_s2l,
+        THRESHOLD_GAMMA as f32,
+        1.0,
+        |v| v,
+        |v| v,
+        (THRESHOLD_GAMMA, THRESHOLD_LINEAR),
+        &[
+            1.724_942_4e-2,
+            8.335_514_7e-1,
+            1.326_215_8e1,
+            7.033_073_4e1,
+            8.387_046e1,
+        ],
+        &[2.066_183e1, 9.917_607e1, 5.466_011e1, -7.183_806, 1.0],
+    );
+
+    // L2S 4/4 (on √x)
+    let l2s = find_best(
+        "L2S 4/4 (base clamped path, on √x, [0, 1])",
+        |s| A1 * (s * s).powf(1.0 / 2.4) - A,
+        THRESHOLD_LINEAR.sqrt(),
+        1.0,
+        4,
+        4,
+        ref_l2s,
+        THRESHOLD_LINEAR as f32,
+        1.0,
+        |v| v.sqrt(),
+        |v| v.sqrt(),
+        (THRESHOLD_LINEAR.sqrt(), THRESHOLD_GAMMA),
+        &[
+            -1.513_885e-2,
+            1.167_372_8e-1,
+            1.257_921_2e1,
+            5.259_309_8e1,
+            2.852_907_6e1,
+        ],
+        &[2.943_901_4e-1, 9.779_103, 4.726_487_7e1, 3.546_463_8e1, 1.0],
+    );
+
+    // EXT_S2L 6/6 (extended [0, 8])
+    let ext_s2l = find_best(
+        "EXT_S2L 6/6 (extended SIMD path, [0, 8])",
+        |v| ((v + A) / A1).powf(2.4),
+        THRESHOLD_GAMMA,
+        8.0,
+        6,
+        6,
+        ref_s2l,
+        THRESHOLD_GAMMA as f32,
+        1.0,
+        |v| v,
+        |v| v,
+        (THRESHOLD_GAMMA, THRESHOLD_LINEAR),
+        &[
+            1.802_136_5e1,
+            9.110_411_4e2,
+            1.570_602_1e4,
+            1.020_638_2e5,
+            2.199_931_2e5,
+            1.338_269_2e5,
+            1.706_519_4e4,
+        ],
+        &[
+            2.159_401_7e4,
+            1.508_555_1e5,
+            2.303_299_0e5,
+            8.239_410_8e4,
+            4.473_249_1e3,
+            -6.359_000_1e1,
+            1.0,
+        ],
+    );
+
+    // EXT_L2S 6/6 (extended √x, [0, 64])
+    let ext_l2s = find_best(
+        "EXT_L2S 6/6 (extended SIMD path, on √x, [0, 64])",
+        |s| A1 * (s * s).powf(1.0 / 2.4) - A,
+        THRESHOLD_LINEAR.sqrt(),
+        8.0,
+        6,
+        6,
+        ref_l2s,
+        THRESHOLD_LINEAR as f32,
+        1.0,
+        |v| v.sqrt(),
+        |v| v.sqrt(),
+        (THRESHOLD_LINEAR.sqrt(), THRESHOLD_GAMMA),
+        &[
+            -1.025_467_4,
+            -3.075_361_5e-1,
+            1.027_286e3,
+            7.093_665e3,
+            1.006_868_9e4,
+            3.230_716e3,
+            1.769_130_4e2,
+        ],
+        &[
+            1.977_460_5e1,
+            8.308_271e2,
+            6.024_792_5e3,
+            1.024_407_5e4,
+            4.157_534e3,
+            3.179_324_6e2,
+            1.0,
+        ],
+    );
+
+    // Final summary
+    println!("\n\n{}", "=".repeat(70));
+    println!("  COEFFICIENTS FOR linear-srgb/src/rational_poly.rs");
+    println!("{}\n", "=".repeat(70));
+    print_coeffs(
+        "S2L_P",
+        &s2l.numerator,
+        &format!(
+            "sRGB EOTF (encoded → linear) numerator coefficients. Max {} ULP, boundary {} ULP.",
+            s2l.max_ulp, s2l.boundary_ulp
+        ),
+    );
+    print_coeffs(
+        "S2L_Q",
+        &s2l.denominator,
+        "sRGB EOTF (encoded → linear) denominator coefficients.",
+    );
+    println!();
+    print_coeffs("L2S_P", &l2s.numerator,
+        &format!("sRGB inverse EOTF (linear → encoded) numerator coefficients. Max {} ULP, boundary {} ULP. Evaluated on sqrt(linear).",
+            l2s.max_ulp, l2s.boundary_ulp));
+    print_coeffs(
+        "L2S_Q",
+        &l2s.denominator,
+        "sRGB inverse EOTF (linear → encoded) denominator coefficients. Evaluated on sqrt(linear).",
+    );
+    println!();
+    print_coeffs("EXT_S2L_P", &ext_s2l.numerator,
+        &format!("Extended sRGB EOTF numerator (degree 6, fitted to [threshold, 8]). Max {} ULP in [0,1], boundary {} ULP.",
+            ext_s2l.max_ulp, ext_s2l.boundary_ulp));
+    print_coeffs(
+        "EXT_S2L_Q",
+        &ext_s2l.denominator,
+        "Extended sRGB EOTF denominator (degree 6, fitted to [threshold, 8]).",
+    );
+    println!();
+    print_coeffs("EXT_L2S_P", &ext_l2s.numerator,
+        &format!("Extended sRGB inverse EOTF numerator (degree 6, on sqrt to [threshold, 64]). Max {} ULP in [0,1], boundary {} ULP.",
+            ext_l2s.max_ulp, ext_l2s.boundary_ulp));
+    print_coeffs(
+        "EXT_L2S_Q",
+        &ext_l2s.denominator,
+        "Extended sRGB inverse EOTF denominator (degree 6, on sqrt to [threshold, 64]).",
+    );
+}

--- a/examples/joint_roundtrip.rs
+++ b/examples/joint_roundtrip.rs
@@ -1,0 +1,447 @@
+//! Jointly optimize S2L and L2S coefficients to minimize roundtrip error.
+//!
+//! Starts from the best individual-fit coefficients, then performs local f32
+//! ULP search with a joint objective: lexicographic (max_ulp, roundtrip_max).
+//! The search explores both polynomials simultaneously — a coefficient nudge
+//! in S2L may correlate with a nudge in L2S that lowers both the direct ULP
+//! AND the roundtrip error.
+//!
+//! Run: cargo run --release --example joint_roundtrip
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_lossless,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap
+)]
+
+const A: f64 = 0.055_010_718_947_586_6;
+const A1: f64 = 1.0 + A;
+const THRESHOLD_LINEAR: f64 = 0.003_041_282_560_127_521;
+const THRESHOLD_GAMMA: f64 = 12.92 * THRESHOLD_LINEAR;
+const LINEAR_SCALE: f32 = 1.0 / 12.92;
+const TWELVE_92: f32 = 12.92;
+
+fn ref_s2l(v: f64) -> f64 {
+    if v <= THRESHOLD_GAMMA {
+        v / 12.92
+    } else {
+        ((v + A) / A1).powf(2.4)
+    }
+}
+fn ref_l2s(v: f64) -> f64 {
+    if v <= THRESHOLD_LINEAR {
+        v * 12.92
+    } else {
+        A1 * v.powf(1.0 / 2.4) - A
+    }
+}
+
+fn eval_f64mid(x: f32, p: &[f32], q: &[f32]) -> f32 {
+    let x = x as f64;
+    let mut yp = *p.last().unwrap() as f64;
+    for &c in p[..p.len() - 1].iter().rev() {
+        yp = yp.mul_add(x, c as f64);
+    }
+    let mut yq = *q.last().unwrap() as f64;
+    for &c in q[..q.len() - 1].iter().rev() {
+        yq = yq.mul_add(x, c as f64);
+    }
+    (yp / yq) as f32
+}
+
+fn ulp_dist(a: f32, b: f32) -> u32 {
+    if a == b {
+        return 0;
+    }
+    if a.is_nan() || b.is_nan() {
+        return u32::MAX;
+    }
+    let map = |v: f32| -> i64 {
+        let bits = v.to_bits() as i32;
+        i64::from(if bits < 0 { i32::MIN - bits } else { bits })
+    };
+    (map(a) - map(b)).unsigned_abs() as u32
+}
+
+fn f32_next(v: f32) -> f32 {
+    if v.is_nan() || v >= f32::MAX {
+        return v;
+    }
+    if v == 0.0 {
+        return f32::from_bits(1);
+    }
+    if v > 0.0 {
+        f32::from_bits(v.to_bits() + 1)
+    } else {
+        f32::from_bits(v.to_bits() - 1)
+    }
+}
+
+fn f32_nudge(v: f32, delta: i32) -> f32 {
+    f32::from_bits((v.to_bits() as i32 + delta) as u32)
+}
+
+// Full sRGB fast forward with piecewise threshold
+fn srgb_to_linear(v: f32, s2l_p: &[f32], s2l_q: &[f32]) -> f32 {
+    if v < 0.0 {
+        return 0.0;
+    }
+    if v >= 1.0 {
+        return 1.0;
+    }
+    if v <= THRESHOLD_GAMMA as f32 {
+        return v * LINEAR_SCALE;
+    }
+    eval_f64mid(v, s2l_p, s2l_q)
+}
+
+fn linear_to_srgb(v: f32, l2s_p: &[f32], l2s_q: &[f32]) -> f32 {
+    if v < 0.0 {
+        return 0.0;
+    }
+    if v >= 1.0 {
+        return 1.0;
+    }
+    if v <= THRESHOLD_LINEAR as f32 {
+        return v * TWELVE_92;
+    }
+    eval_f64mid(v.sqrt(), l2s_p, l2s_q)
+}
+
+struct Score {
+    s2l_max_ulp: u32,
+    s2l_avg_ulp: f64,
+    s2l_bnd: u32,
+    l2s_max_ulp: u32,
+    l2s_avg_ulp: f64,
+    l2s_bnd: u32,
+    rt_fwd_max: u32,   // roundtrip s2l then l2s: max output ULP vs input
+    rt_fwd_over1: u64, // count of inputs where roundtrip exceeds 1 u16 step
+    rt_inv_max: u32,   // roundtrip l2s then s2l
+    rt_inv_over1: u64,
+    mono_viol: u64,
+}
+
+const U16_STEP: f64 = 1.0 / 65535.0;
+
+fn score(s2l_p: &[f32], s2l_q: &[f32], l2s_p: &[f32], l2s_q: &[f32]) -> Score {
+    // Sampled: 500K uniformly-spaced points. Fast enough to iterate.
+    // Final result should be verified exhaustively.
+    const N: usize = 500_000;
+    let mut s2l_max = 0u32;
+    let mut s2l_sum = 0u64;
+    let mut l2s_max = 0u32;
+    let mut l2s_sum = 0u64;
+    let mut rt_fwd_max = 0u32;
+    let mut rt_fwd_over = 0u64;
+    let mut rt_inv_max = 0u32;
+    let mut rt_inv_over = 0u64;
+    let mut count = 0u64;
+    let mut mono = 0u64;
+    let mut prev_s2l = srgb_to_linear(0.0, s2l_p, s2l_q);
+    let mut prev_l2s = linear_to_srgb(0.0, l2s_p, l2s_q);
+
+    for i in 0..=N {
+        let v = (i as f64 / N as f64) as f32;
+        let s2l_got = srgb_to_linear(v, s2l_p, s2l_q);
+        let s2l_ref = ref_s2l(v as f64) as f32;
+        let u = ulp_dist(s2l_got, s2l_ref);
+        if u > s2l_max {
+            s2l_max = u;
+        }
+        s2l_sum += u as u64;
+
+        let l2s_got = linear_to_srgb(v, l2s_p, l2s_q);
+        let l2s_ref = ref_l2s(v as f64) as f32;
+        let u = ulp_dist(l2s_got, l2s_ref);
+        if u > l2s_max {
+            l2s_max = u;
+        }
+        l2s_sum += u as u64;
+
+        let rt_fwd = linear_to_srgb(s2l_got, l2s_p, l2s_q);
+        let rt_fwd_err = (rt_fwd as f64 - v as f64).abs();
+        if rt_fwd_err > U16_STEP {
+            rt_fwd_over += 1;
+        }
+        let u = ulp_dist(rt_fwd, v);
+        if u > rt_fwd_max {
+            rt_fwd_max = u;
+        }
+
+        let rt_inv = srgb_to_linear(l2s_got, s2l_p, s2l_q);
+        let rt_inv_err = (rt_inv as f64 - v as f64).abs();
+        if rt_inv_err > U16_STEP {
+            rt_inv_over += 1;
+        }
+        let u = ulp_dist(rt_inv, v);
+        if u > rt_inv_max {
+            rt_inv_max = u;
+        }
+
+        if count > 0 && s2l_got < prev_s2l {
+            mono += 1;
+        }
+        if count > 0 && l2s_got < prev_l2s {
+            mono += 1;
+        }
+        prev_s2l = s2l_got;
+        prev_l2s = l2s_got;
+        count += 1;
+    }
+
+    let s2l_bnd = ulp_dist(
+        eval_f64mid(THRESHOLD_GAMMA as f32, s2l_p, s2l_q),
+        ref_s2l(THRESHOLD_GAMMA) as f32,
+    );
+    let l2s_bnd = ulp_dist(
+        eval_f64mid((THRESHOLD_LINEAR as f32).sqrt(), l2s_p, l2s_q),
+        ref_l2s(THRESHOLD_LINEAR) as f32,
+    );
+
+    Score {
+        s2l_max_ulp: s2l_max,
+        s2l_avg_ulp: s2l_sum as f64 / count as f64,
+        s2l_bnd,
+        l2s_max_ulp: l2s_max,
+        l2s_avg_ulp: l2s_sum as f64 / count as f64,
+        l2s_bnd,
+        rt_fwd_max,
+        rt_fwd_over1: rt_fwd_over,
+        rt_inv_max,
+        rt_inv_over1: rt_inv_over,
+        mono_viol: mono,
+    }
+}
+
+fn print_score(label: &str, s: &Score) {
+    println!(
+        "{label}:\n  S2L max={} avg={:.3} bnd={}\n  L2S max={} avg={:.3} bnd={}\n  RT fwd max={} over1={}, inv max={} over1={}\n  mono={}",
+        s.s2l_max_ulp, s.s2l_avg_ulp, s.s2l_bnd,
+        s.l2s_max_ulp, s.l2s_avg_ulp, s.l2s_bnd,
+        s.rt_fwd_max, s.rt_fwd_over1, s.rt_inv_max, s.rt_inv_over1,
+        s.mono_viol,
+    );
+}
+
+/// Scoring: lexicographic. First satisfy hard constraints, then optimize primary/secondary.
+/// - mono = 0 (hard)
+/// - S2L bnd <= 2, L2S bnd <= 2 (hard, for piecewise continuity)
+/// - rt_over1 = 0 (hard: no roundtrip exceeds 1 u16 step)
+/// - minimize max(s2l_max, l2s_max) + rt_max sum
+fn score_cmp(a: &Score, b: &Score) -> std::cmp::Ordering {
+    use std::cmp::Ordering::*;
+    let ok_a = a.mono_viol == 0
+        && a.s2l_bnd <= 2
+        && a.l2s_bnd <= 2
+        && a.rt_fwd_over1 == 0
+        && a.rt_inv_over1 == 0;
+    let ok_b = b.mono_viol == 0
+        && b.s2l_bnd <= 2
+        && b.l2s_bnd <= 2
+        && b.rt_fwd_over1 == 0
+        && b.rt_inv_over1 == 0;
+    match (ok_a, ok_b) {
+        (true, false) => return Less,
+        (false, true) => return Greater,
+        _ => {}
+    }
+    // Primary: max of (S2L max_ulp, L2S max_ulp)
+    let max_a = a.s2l_max_ulp.max(a.l2s_max_ulp);
+    let max_b = b.s2l_max_ulp.max(b.l2s_max_ulp);
+    match max_a.cmp(&max_b) {
+        Equal => {}
+        o => return o,
+    }
+    // Secondary: sum of roundtrip maxes
+    let rt_a = a.rt_fwd_max + a.rt_inv_max;
+    let rt_b = b.rt_fwd_max + b.rt_inv_max;
+    match rt_a.cmp(&rt_b) {
+        Equal => {}
+        o => return o,
+    }
+    // Tertiary: sum of avg ULPs
+    a.s2l_avg_ulp.partial_cmp(&b.s2l_avg_ulp).unwrap_or(Equal)
+}
+
+fn joint_search(
+    s2l_p: &mut Vec<f32>,
+    s2l_q: &mut Vec<f32>,
+    l2s_p: &mut Vec<f32>,
+    l2s_q: &mut Vec<f32>,
+) {
+    // Each polynomial has p.len() + q.len() - 1 free coeffs (last q is 1.0)
+    let s2l_n = s2l_p.len() + s2l_q.len() - 1;
+    let l2s_n = l2s_p.len() + l2s_q.len() - 1;
+    let total = s2l_n + l2s_n;
+
+    let mut best = score(s2l_p, s2l_q, l2s_p, l2s_q);
+    println!("\nInitial score:");
+    print_score("  init", &best);
+
+    for round in 1..=5 {
+        let mut improved = false;
+        for ci in 0..total {
+            let (is_s2l, local_ci) = if ci < s2l_n {
+                (true, ci)
+            } else {
+                (false, ci - s2l_n)
+            };
+            let (vec_p, vec_q) = if is_s2l {
+                (&mut *s2l_p, &mut *s2l_q)
+            } else {
+                (&mut *l2s_p, &mut *l2s_q)
+            };
+            let is_p = local_ci < vec_p.len();
+            let idx = if is_p {
+                local_ci
+            } else {
+                local_ci - vec_p.len()
+            };
+            let original = if is_p { vec_p[idx] } else { vec_q[idx] };
+
+            let mut best_delta = 0i32;
+            for delta in (-3..=3).filter(|&d| d != 0) {
+                let nudged = f32_nudge(original, delta);
+                if is_s2l {
+                    if is_p {
+                        s2l_p[idx] = nudged;
+                    } else {
+                        s2l_q[idx] = nudged;
+                    }
+                } else {
+                    if is_p {
+                        l2s_p[idx] = nudged;
+                    } else {
+                        l2s_q[idx] = nudged;
+                    }
+                }
+                let s = score(s2l_p, s2l_q, l2s_p, l2s_q);
+                if score_cmp(&s, &best) == std::cmp::Ordering::Less {
+                    best = s;
+                    best_delta = delta;
+                }
+                // Revert
+                if is_s2l {
+                    if is_p {
+                        s2l_p[idx] = original;
+                    } else {
+                        s2l_q[idx] = original;
+                    }
+                } else {
+                    if is_p {
+                        l2s_p[idx] = original;
+                    } else {
+                        l2s_q[idx] = original;
+                    }
+                }
+            }
+
+            if best_delta != 0 {
+                let nudged = f32_nudge(original, best_delta);
+                if is_s2l {
+                    if is_p {
+                        s2l_p[idx] = nudged;
+                    } else {
+                        s2l_q[idx] = nudged;
+                    }
+                } else {
+                    if is_p {
+                        l2s_p[idx] = nudged;
+                    } else {
+                        l2s_q[idx] = nudged;
+                    }
+                }
+                let which = if is_s2l { "S2L" } else { "L2S" };
+                let kind = if is_p { "P" } else { "Q" };
+                println!("  round {round} {which}.{kind}[{idx}] {best_delta:+}: S2L={} L2S={} rt_fwd={} rt_inv={}",
+                    best.s2l_max_ulp, best.l2s_max_ulp, best.rt_fwd_max, best.rt_inv_max);
+                improved = true;
+            }
+        }
+        if !improved {
+            println!("  round {round}: converged");
+            break;
+        }
+    }
+
+    println!("\nFinal score:");
+    print_score("  final", &best);
+}
+
+fn print_const(name: &str, coeffs: &[f32]) {
+    println!("pub(crate) const {name}: [f32; {}] = [", coeffs.len());
+    for (i, &c) in coeffs.iter().enumerate() {
+        let comma = if i + 1 < coeffs.len() { "," } else { "" };
+        println!("    {c:.10e}{comma}");
+    }
+    println!("];");
+}
+
+fn main() {
+    // Baseline: main branch (before PR #8)
+    let main_s2l_p: Vec<f32> = vec![
+        1.724_942_4e-2,
+        8.335_514_7e-1,
+        1.326_215_8e1,
+        7.033_073_4e1,
+        8.387_046e1,
+    ];
+    let main_s2l_q: Vec<f32> = vec![2.066_183e1, 9.917_607e1, 5.466_011e1, -7.183_806, 1.0];
+    let main_l2s_p: Vec<f32> = vec![
+        -1.513_885e-2,
+        1.167_372_8e-1,
+        1.257_921_2e1,
+        5.259_309_8e1,
+        2.852_907_6e1,
+    ];
+    let main_l2s_q: Vec<f32> = vec![2.943_901_4e-1, 9.779_103, 4.726_487_7e1, 3.546_463_8e1, 1.0];
+
+    println!("=== MAIN BRANCH (current release) ===");
+    let main_score = score(&main_s2l_p, &main_s2l_q, &main_l2s_p, &main_l2s_q);
+    print_score("  main", &main_score);
+
+    // PR branch coefficients (already polyfit-optimized individually)
+    let mut s2l_p = vec![
+        1.672_814_6e-2,
+        8.089_536_4e-1,
+        1.288_439_66e1,
+        6.854_374_7e1,
+        8.224_625_4e1,
+    ];
+    let mut s2l_q = vec![
+        2.003_807_83e1,
+        9.681_468_2e1,
+        5.377_303_3e1,
+        -7.125_638,
+        1.0,
+    ];
+    let mut l2s_p = vec![
+        -1.356_440_97e-2,
+        9.336_896_24e-2,
+        1.157_270_53e1,
+        5.002_124_79e1,
+        2.792_420_96e1,
+    ];
+    let mut l2s_q = vec![
+        2.633_812_73e-1,
+        8.998_917_58,
+        4.477_739_72e1,
+        3.455_830_76e1,
+        1.0,
+    ];
+
+    println!("\n=== Joint S2L/L2S roundtrip optimization ===");
+    println!("Starting from individually-optimized polyfit coefficients (PR #8)");
+
+    joint_search(&mut s2l_p, &mut s2l_q, &mut l2s_p, &mut l2s_q);
+
+    println!("\n{}", "=".repeat(60));
+    println!("  Final coefficients");
+    println!("{}\n", "=".repeat(60));
+    print_const("S2L_P", &s2l_p);
+    print_const("S2L_Q", &s2l_q);
+    print_const("L2S_P", &l2s_p);
+    print_const("L2S_Q", &l2s_q);
+}

--- a/examples/optimize_srgb.rs
+++ b/examples/optimize_srgb.rs
@@ -1,0 +1,411 @@
+//! Optimize sRGB rational polynomial coefficients for the linear-srgb crate.
+//!
+//! Evaluates with f64-intermediate Horner (matching linear-srgb's scalar path).
+//! Exhaustive sweep of every f32 in the power segment [threshold, 1.0].
+//!
+//! Covers:
+//!   S2L 4/4 — base clamped path, ((v + offset) / scale)^2.4
+//!   L2S 4/4 — base clamped path, evaluated on √(linear)
+//!   S2L 6/6 — extended SIMD path [threshold, 8]
+//!   L2S 6/6 — extended SIMD path on √x [threshold, 64]
+//!
+//! Run: cargo run --release --example optimize_srgb
+
+use polyfit::rational::{
+    Constraint, ConstraintMode, ErrorWeighting, F32SearchConfig, RationalFit, RationalFitOptions,
+};
+
+// =============================================================================
+// sRGB constants (C0-continuous, moxcms-derived)
+// =============================================================================
+
+const A: f64 = 0.055_010_718_947_586_6;
+const A1: f64 = 1.0 + A;
+const THRESHOLD_LINEAR: f64 = 0.003_041_282_560_127_521;
+const THRESHOLD_GAMMA: f64 = 12.92 * THRESHOLD_LINEAR;
+
+fn ref_s2l(v: f64) -> f64 {
+    if v <= THRESHOLD_GAMMA {
+        v / 12.92
+    } else {
+        ((v + A) / A1).powf(2.4)
+    }
+}
+fn ref_l2s(v: f64) -> f64 {
+    if v <= THRESHOLD_LINEAR {
+        v * 12.92
+    } else {
+        A1 * v.powf(1.0 / 2.4) - A
+    }
+}
+
+// =============================================================================
+// f32 measurement utilities (sign-correct ULP, f64-intermediate Horner)
+// =============================================================================
+
+/// Evaluate rational polynomial with f32 coefficients via f64 Horner.
+/// Matches eval_rational_poly_5 in linear-srgb/src/rational_poly.rs.
+fn eval_f64mid(x: f32, p: &[f32], q: &[f32]) -> f32 {
+    let x = x as f64;
+    let mut yp = *p.last().unwrap() as f64;
+    for &c in p[..p.len() - 1].iter().rev() {
+        yp = yp.mul_add(x, c as f64);
+    }
+    let mut yq = *q.last().unwrap() as f64;
+    for &c in q[..q.len() - 1].iter().rev() {
+        yq = yq.mul_add(x, c as f64);
+    }
+    (yp / yq) as f32
+}
+
+/// ULP distance handling sign crossings correctly.
+fn ulp_dist(a: f32, b: f32) -> u32 {
+    if a == b {
+        return 0;
+    }
+    if a.is_nan() || b.is_nan() {
+        return u32::MAX;
+    }
+    let map = |v: f32| -> i64 {
+        let bits = v.to_bits() as i32;
+        i64::from(if bits < 0 { i32::MIN - bits } else { bits })
+    };
+    (map(a) - map(b)).unsigned_abs() as u32
+}
+
+fn f32_next(v: f32) -> f32 {
+    if v.is_nan() || v >= f32::MAX {
+        return v;
+    }
+    if v == 0.0 {
+        return f32::from_bits(1);
+    }
+    if v > 0.0 {
+        f32::from_bits(v.to_bits() + 1)
+    } else {
+        f32::from_bits(v.to_bits() - 1)
+    }
+}
+
+struct Metrics {
+    max_ulp: u32,
+    avg_ulp: f64,
+    bnd: u32,
+    mono: u64,
+    count: u64,
+}
+
+impl std::fmt::Display for Metrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "max={:>3} bnd={} avg={:.3} mono={} ({:.1}M values)",
+            self.max_ulp,
+            self.bnd,
+            self.avg_ulp,
+            self.mono,
+            self.count as f64 / 1e6
+        )
+    }
+}
+
+/// Exhaustive sweep of every f32 in [lo, hi], with optional input transform.
+fn measure(
+    p: &[f32],
+    q: &[f32],
+    reference: impl Fn(f64) -> f64,
+    lo: f32,
+    hi: f32,
+    xform: impl Fn(f32) -> f32,
+) -> Metrics {
+    let mut max_ulp = 0u32;
+    let mut sum = 0u64;
+    let mut count = 0u64;
+    let mut mono = 0u64;
+    let mut prev = eval_f64mid(xform(lo), p, q);
+    let mut v = lo;
+    while v <= hi {
+        let got = eval_f64mid(xform(v), p, q);
+        let expected = reference(v as f64) as f32;
+        let ulp = ulp_dist(got, expected);
+        if ulp > max_ulp {
+            max_ulp = ulp;
+        }
+        sum += ulp as u64;
+        count += 1;
+        if v > lo && got < prev {
+            mono += 1;
+        }
+        prev = got;
+        v = f32_next(v);
+    }
+    let bnd = ulp_dist(eval_f64mid(xform(lo), p, q), reference(lo as f64) as f32);
+    Metrics {
+        max_ulp,
+        avg_ulp: sum as f64 / count.max(1) as f64,
+        bnd,
+        mono,
+        count,
+    }
+}
+
+/// Measure u16 and u8 safe boundaries via dense sampling.
+fn safe_bounds(
+    p: &[f32],
+    q: &[f32],
+    reference: impl Fn(f64) -> f64,
+    lo: f64,
+    hi: f64,
+    xform: impl Fn(f64) -> f64,
+) -> (f64, f64, f64) {
+    let u16_h = 0.5 / 65535.0;
+    let u16_1 = 1.0 / 65535.0;
+    let u8_h = 0.5 / 255.0;
+    let (mut u16_exact, mut u16_pm1, mut u8_safe) = (hi, hi, hi);
+    let n = 10_000_000;
+    for i in 0..=n {
+        let x = lo + (hi - lo) * i as f64 / n as f64;
+        let got = eval_f64mid(xform(x) as f32, p, q) as f64;
+        let err = (got - reference(x)).abs();
+        if err >= u16_h && x < u16_exact {
+            u16_exact = x;
+        }
+        if err >= u16_1 && x < u16_pm1 {
+            u16_pm1 = x;
+        }
+        if err >= u8_h && x < u8_safe {
+            u8_safe = x;
+        }
+    }
+    (u16_exact, u16_pm1, u8_safe)
+}
+
+fn fit_and_report(
+    label: &str,
+    fit_fn: impl Fn(f64) -> f64,
+    domain_lo: f64,
+    domain_hi: f64,
+    p_deg: usize,
+    q_deg: usize,
+    reference: impl Fn(f64) -> f64 + Copy,
+    sweep_lo: f32,
+    sweep_hi: f32,
+    xform: impl Fn(f32) -> f32 + Copy,
+    xform_f64: impl Fn(f64) -> f64 + Copy,
+    constraint: Option<(f64, f64)>,
+    current_p: &[f32],
+    current_q: &[f32],
+    safe_hi: f64,
+) {
+    println!("\n{}", "=".repeat(65));
+    println!("  {label}");
+    println!("{}\n", "=".repeat(65));
+
+    // --- Current coefficients ---
+    let cur = measure(current_p, current_q, reference, sweep_lo, sweep_hi, xform);
+    println!("Current:    {cur}");
+    if safe_hi > 1.0 {
+        let (u16e, u16p, u8s) = safe_bounds(
+            current_p,
+            current_q,
+            reference,
+            sweep_lo as f64,
+            safe_hi,
+            xform_f64,
+        );
+        println!("            u16\u{00b1}0 \u{2264}{u16e:.2}  u16\u{00b1}1 \u{2264}{u16p:.2}  u8 \u{2264}{u8s:.2}");
+    }
+
+    // --- Fit ---
+    let mut options = RationalFitOptions {
+        weighting: ErrorWeighting::Relative,
+        n_samples: 10_000,
+        restarts: 8,
+        ..RationalFitOptions::default()
+    };
+    if let Some((cx, cy)) = constraint {
+        options.constraints = vec![Constraint::new(cx, cy)];
+        options.constraint_mode = ConstraintMode::SnapOnly;
+    }
+
+    let fit =
+        RationalFit::from_function(fit_fn, domain_lo..=domain_hi, p_deg, q_deg, options).unwrap();
+
+    // --- Boundary report ---
+    let report = fit.boundary_error(reference);
+    println!("\n{report}");
+
+    // --- f32 optimization (uses f64-intermediate Horner internally) ---
+    let result = fit.as_polynomial().optimize_f32(
+        reference,
+        sweep_lo,
+        sweep_hi,
+        xform,
+        F32SearchConfig::default(),
+    );
+    println!("Optimized:  {result}");
+
+    if safe_hi > 1.0 {
+        let (u16e, u16p, u8s) = safe_bounds(
+            &result.numerator,
+            &result.denominator,
+            reference,
+            sweep_lo as f64,
+            safe_hi,
+            xform_f64,
+        );
+        println!("            u16\u{00b1}0 \u{2264}{u16e:.2}  u16\u{00b1}1 \u{2264}{u16p:.2}  u8 \u{2264}{u8s:.2}");
+    }
+
+    // --- Comparison ---
+    let better_max = result.max_ulp < cur.max_ulp;
+    let better_avg = result.max_ulp == cur.max_ulp && result.avg_ulp < cur.avg_ulp;
+    if better_max || better_avg {
+        println!(
+            "\n  >>> IMPROVED: max {} \u{2192} {}, avg {:.2} \u{2192} {:.2}",
+            cur.max_ulp, result.max_ulp, cur.avg_ulp, result.avg_ulp
+        );
+    } else if result.max_ulp == cur.max_ulp {
+        println!("\n  --- MATCHED max ULP");
+    } else {
+        println!(
+            "\n  !!! WORSE: max {} \u{2192} {}",
+            cur.max_ulp, result.max_ulp
+        );
+    }
+
+    println!("\nP: {:?}", result.numerator);
+    println!("Q: {:?}", result.denominator);
+
+    // Rust const format
+    println!("\n// Rust const:");
+    print_const("P", &result.numerator);
+    print_const("Q", &result.denominator);
+}
+
+fn print_const(name: &str, coeffs: &[f32]) {
+    println!("const {name}: [f32; {}] = [", coeffs.len());
+    for (i, &c) in coeffs.iter().enumerate() {
+        let comma = if i + 1 < coeffs.len() { "," } else { "" };
+        println!("    {c:>16.6e}{comma}");
+    }
+    println!("];");
+}
+
+fn main() {
+    fit_and_report(
+        "S2L 4/4 \u{2014} sRGB encoded \u{2192} linear [0, 1]",
+        |v| ((v + A) / A1).powf(2.4),
+        THRESHOLD_GAMMA,
+        1.0,
+        4,
+        4,
+        ref_s2l,
+        THRESHOLD_GAMMA as f32,
+        1.0,
+        |v| v,
+        |v| v,
+        Some((THRESHOLD_GAMMA, THRESHOLD_LINEAR)),
+        &[
+            1.724_942_4e-2,
+            8.335_514_7e-1,
+            1.326_215_8e1,
+            7.033_073_4e1,
+            8.387_046e1,
+        ],
+        &[2.066_183e1, 9.917_607e1, 5.466_011e1, -7.183_806, 1.0],
+        1.0,
+    );
+
+    fit_and_report(
+        "L2S 4/4 \u{2014} linear \u{2192} sRGB encoded [0, 1] (on \u{221a}x)",
+        |s| A1 * (s * s).powf(1.0 / 2.4) - A,
+        THRESHOLD_LINEAR.sqrt(),
+        1.0,
+        4,
+        4,
+        ref_l2s,
+        THRESHOLD_LINEAR as f32,
+        1.0,
+        |v| v.sqrt(),
+        |v| v.sqrt(),
+        Some((THRESHOLD_LINEAR.sqrt(), THRESHOLD_GAMMA)),
+        &[
+            -1.513_885e-2,
+            1.167_372_8e-1,
+            1.257_921_2e1,
+            5.259_309_8e1,
+            2.852_907_6e1,
+        ],
+        &[2.943_901_4e-1, 9.779_103, 4.726_487_7e1, 3.546_463_8e1, 1.0],
+        1.0,
+    );
+
+    fit_and_report(
+        "S2L 6/6 \u{2014} sRGB encoded \u{2192} linear [0, 8] (extended)",
+        |v| ((v + A) / A1).powf(2.4),
+        THRESHOLD_GAMMA,
+        8.0,
+        6,
+        6,
+        ref_s2l,
+        THRESHOLD_GAMMA as f32,
+        1.0,
+        |v| v,
+        |v| v,
+        Some((THRESHOLD_GAMMA, THRESHOLD_LINEAR)),
+        &[
+            1.802_136_5e1,
+            9.110_411_4e2,
+            1.570_602_1e4,
+            1.020_638_2e5,
+            2.199_931_2e5,
+            1.338_269_2e5,
+            1.706_519_4e4,
+        ],
+        &[
+            2.159_401_7e4,
+            1.508_555_1e5,
+            2.303_299_0e5,
+            8.239_410_8e4,
+            4.473_249_1e3,
+            -6.359_000_1e1,
+            1.0,
+        ],
+        8.0,
+    );
+
+    fit_and_report(
+        "L2S 6/6 \u{2014} linear \u{2192} sRGB encoded [0, 64] on \u{221a}x (extended)",
+        |s| A1 * (s * s).powf(1.0 / 2.4) - A,
+        THRESHOLD_LINEAR.sqrt(),
+        8.0,
+        6,
+        6,
+        ref_l2s,
+        THRESHOLD_LINEAR as f32,
+        1.0,
+        |v| v.sqrt(),
+        |v| v.sqrt(),
+        Some((THRESHOLD_LINEAR.sqrt(), THRESHOLD_GAMMA)),
+        &[
+            -1.780_184_6,
+            5.030_732_0,
+            1.656_664_9e3,
+            1.017_330_6e4,
+            1.298_072_5e4,
+            3.771_270_8e3,
+            1.888_817_8e2,
+        ],
+        &[
+            3.446_206_7e1,
+            1.327_327_9e3,
+            8.730_898_7e3,
+            1.340_767_0e4,
+            4.928_503_9e3,
+            3.442_401_8e2,
+            1.0,
+        ],
+        64.0,
+    );
+}

--- a/examples/optimize_transcendentals.rs
+++ b/examples/optimize_transcendentals.rs
@@ -1,0 +1,569 @@
+//! Optimize rational polynomial coefficients for fast transcendentals.
+//!
+//! These polynomials are evaluated in pure f32 (SIMD), not f64-intermediate.
+//! Uses sampled measurement because the polynomial input domain is the
+//! transformed variable, not the original function domain.
+//!
+//! For each target, tries two strategies and keeps the best:
+//!   A) Fresh fit (SK + LM + multi-restart from random)
+//!   B) Warm-start LM refinement from the existing coefficients
+//!
+//! For log2 (output crosses zero), uses absolute-error metric.
+//!
+//! Run: cargo run --release --example optimize_transcendentals
+
+use polyfit::rational::{
+    ErrorWeighting, F32ScoreMetric, F32SearchConfig, F32SearchResult, RationalFit,
+    RationalFitOptions, RationalPolynomial,
+};
+
+// =============================================================================
+// f32 measurement (pure f32 Horner — matches SIMD evaluation)
+// =============================================================================
+
+fn eval_f32(x: f32, p: &[f32], q: &[f32]) -> f32 {
+    let mut yp = *p.last().unwrap();
+    for &c in p[..p.len() - 1].iter().rev() {
+        yp = yp.mul_add(x, c);
+    }
+    let mut yq = *q.last().unwrap();
+    for &c in q[..q.len() - 1].iter().rev() {
+        yq = yq.mul_add(x, c);
+    }
+    yp / yq
+}
+
+fn ulp_dist(a: f32, b: f32) -> u32 {
+    if a == b {
+        return 0;
+    }
+    if a.is_nan() || b.is_nan() {
+        return u32::MAX;
+    }
+    let map = |v: f32| -> i64 {
+        let bits = v.to_bits() as i32;
+        i64::from(if bits < 0 { i32::MIN - bits } else { bits })
+    };
+    (map(a) - map(b)).unsigned_abs() as u32
+}
+
+#[derive(Clone, Copy)]
+struct Metrics {
+    max_ulp: u32,
+    avg_ulp: f64,
+    max_abs: f64,
+    avg_abs: f64,
+}
+
+impl std::fmt::Display for Metrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "max_ulp={:>4} avg_ulp={:>7.3} max_abs={:.3e} avg_abs={:.3e}",
+            self.max_ulp, self.avg_ulp, self.max_abs, self.avg_abs,
+        )
+    }
+}
+
+fn measure(
+    p: &[f32],
+    q: &[f32],
+    reference: impl Fn(f64) -> f64,
+    lo: f32,
+    hi: f32,
+    n: usize,
+) -> Metrics {
+    let mut max_ulp = 0u32;
+    let mut sum_ulp = 0u64;
+    let mut max_abs: f64 = 0.0;
+    let mut sum_abs: f64 = 0.0;
+    for i in 0..=n {
+        let x = lo as f64 + (hi as f64 - lo as f64) * i as f64 / n as f64;
+        let got = eval_f32(x as f32, p, q);
+        let expected = reference(x) as f32;
+        let ulp = ulp_dist(got, expected);
+        let abs_err = (f64::from(got) - f64::from(expected)).abs();
+        if ulp > max_ulp {
+            max_ulp = ulp;
+        }
+        if abs_err > max_abs {
+            max_abs = abs_err;
+        }
+        sum_ulp += u64::from(ulp);
+        sum_abs += abs_err;
+    }
+    Metrics {
+        max_ulp,
+        avg_ulp: sum_ulp as f64 / (n + 1) as f64,
+        max_abs,
+        avg_abs: sum_abs / (n + 1) as f64,
+    }
+}
+
+// =============================================================================
+// PQ reference
+// =============================================================================
+
+fn pq_eotf_exact(v: f64) -> f64 {
+    let (m1, m2) = (0.159_301_757_812_5_f64, 78.843_75_f64);
+    let (c1, c2, c3) = (0.835_937_5_f64, 18.851_562_5_f64, 18.687_5_f64);
+    let vp = v.powf(1.0 / m2);
+    let num = (vp - c1).max(0.0);
+    let den = c2 - c3 * vp;
+    if den <= 0.0 {
+        1.0
+    } else {
+        (num / den).powf(1.0 / m1)
+    }
+}
+
+fn pq_inv_exact(v: f64) -> f64 {
+    let (m1, m2) = (0.159_301_757_812_5_f64, 78.843_75_f64);
+    let (c1, c2, c3) = (0.835_937_5_f64, 18.851_562_5_f64, 18.687_5_f64);
+    let vp = v.powf(m1);
+    ((c1 + c2 * vp) / (1.0 + c3 * vp)).powf(m2)
+}
+
+// =============================================================================
+// Chebyshev data generator (for warm-start LM)
+// =============================================================================
+
+fn chebyshev_data(f: impl Fn(f64) -> f64, lo: f64, hi: f64, n: usize) -> Vec<(f64, f64)> {
+    let pi = std::f64::consts::PI;
+    (0..n)
+        .map(|k| {
+            let theta = pi * (2.0 * k as f64 + 1.0) / (2.0 * n as f64);
+            let x = (lo + hi) / 2.0 + (hi - lo) / 2.0 * theta.cos();
+            (x, f(x))
+        })
+        .collect()
+}
+
+// =============================================================================
+// Strategy runner
+// =============================================================================
+
+struct Strategy {
+    label: &'static str,
+    result: F32SearchResult,
+}
+
+fn run_both_strategies(
+    fit_fn: impl Fn(f64) -> f64 + Copy,
+    domain_lo: f64,
+    domain_hi: f64,
+    p_deg: usize,
+    q_deg: usize,
+    reference: impl Fn(f64) -> f64 + Copy,
+    sweep_lo: f32,
+    sweep_hi: f32,
+    current_p: &[f32],
+    current_q: &[f32],
+    metric: F32ScoreMetric,
+) -> Vec<Strategy> {
+    let config = F32SearchConfig {
+        metric,
+        samples: Some(100_000),
+        ..F32SearchConfig::default()
+    };
+
+    // Strategy A: fresh fit
+    let fresh = {
+        let options = RationalFitOptions {
+            weighting: ErrorWeighting::Relative,
+            n_samples: 10_000,
+            restarts: 4,
+            ..RationalFitOptions::default()
+        };
+        let fit = RationalFit::from_function(fit_fn, domain_lo..=domain_hi, p_deg, q_deg, options)
+            .unwrap();
+        fit.as_polynomial()
+            .optimize_f32(reference, sweep_lo, sweep_hi, |v| v, config.clone())
+    };
+
+    // Strategy B: warm-start from existing coefficients
+    let warm = {
+        let data = chebyshev_data(fit_fn, domain_lo, domain_hi, 10_000);
+        RationalPolynomial::<f64>::refine_from_f32(
+            current_p,
+            current_q,
+            reference,
+            &data,
+            sweep_lo,
+            sweep_hi,
+            |v| v,
+            config,
+            ErrorWeighting::Relative,
+            200,
+        )
+    };
+
+    vec![
+        Strategy {
+            label: "fresh fit      ",
+            result: fresh,
+        },
+        Strategy {
+            label: "warm-start LM  ",
+            result: warm,
+        },
+    ]
+}
+
+fn report_strategies(
+    label: &str,
+    current_p: &[f32],
+    current_q: &[f32],
+    reference: impl Fn(f64) -> f64 + Copy,
+    sweep_lo: f32,
+    sweep_hi: f32,
+    strategies: Vec<Strategy>,
+    metric: F32ScoreMetric,
+) {
+    println!("\n{}", "=".repeat(70));
+    println!("  {label}");
+    println!("{}\n", "=".repeat(70));
+
+    let cur = measure(
+        current_p, current_q, reference, sweep_lo, sweep_hi, 1_000_000,
+    );
+    println!("Current:           {cur}");
+
+    let mut best: Option<&Strategy> = None;
+    for s in &strategies {
+        let m = measure(
+            &s.result.numerator,
+            &s.result.denominator,
+            reference,
+            sweep_lo,
+            sweep_hi,
+            1_000_000,
+        );
+        println!("{}:  {m}", s.label);
+        let is_better = match metric {
+            F32ScoreMetric::Ulp => best.is_none_or(|b| {
+                let bm = measure(
+                    &b.result.numerator,
+                    &b.result.denominator,
+                    reference,
+                    sweep_lo,
+                    sweep_hi,
+                    100_000,
+                );
+                m.max_ulp < bm.max_ulp || (m.max_ulp == bm.max_ulp && m.avg_ulp < bm.avg_ulp)
+            }),
+            F32ScoreMetric::AbsoluteError => best.is_none_or(|b| {
+                let bm = measure(
+                    &b.result.numerator,
+                    &b.result.denominator,
+                    reference,
+                    sweep_lo,
+                    sweep_hi,
+                    100_000,
+                );
+                m.max_abs < bm.max_abs
+            }),
+        };
+        if is_better {
+            best = Some(s);
+        }
+    }
+
+    let best = best.unwrap();
+    let bm = measure(
+        &best.result.numerator,
+        &best.result.denominator,
+        reference,
+        sweep_lo,
+        sweep_hi,
+        1_000_000,
+    );
+
+    match metric {
+        F32ScoreMetric::Ulp => {
+            if bm.max_ulp < cur.max_ulp {
+                println!(
+                    "\n  >>> IMPROVED ({}): max {} \u{2192} {}, avg {:.2} \u{2192} {:.2}",
+                    best.label.trim(),
+                    cur.max_ulp,
+                    bm.max_ulp,
+                    cur.avg_ulp,
+                    bm.avg_ulp
+                );
+            } else if bm.max_ulp == cur.max_ulp && bm.avg_ulp < cur.avg_ulp {
+                println!(
+                    "\n  >>> IMPROVED avg ({}): {:.3} \u{2192} {:.3}",
+                    best.label.trim(),
+                    cur.avg_ulp,
+                    bm.avg_ulp
+                );
+            } else if bm.max_ulp == cur.max_ulp {
+                println!("\n  --- MATCHED");
+            } else {
+                println!("\n  !!! WORSE: max {} \u{2192} {}", cur.max_ulp, bm.max_ulp);
+            }
+        }
+        F32ScoreMetric::AbsoluteError => {
+            if bm.max_abs < cur.max_abs {
+                println!(
+                    "\n  >>> IMPROVED ({}): max_abs {:.3e} \u{2192} {:.3e}",
+                    best.label.trim(),
+                    cur.max_abs,
+                    bm.max_abs
+                );
+            } else {
+                println!("\n  --- no improvement");
+            }
+        }
+    }
+
+    print_const("P", &best.result.numerator);
+    print_const("Q", &best.result.denominator);
+}
+
+fn print_const(name: &str, coeffs: &[f32]) {
+    println!("const {name}: [f32; {}] = [", coeffs.len());
+    for (i, &c) in coeffs.iter().enumerate() {
+        let comma = if i + 1 < coeffs.len() { "," } else { "" };
+        println!("    {c:>20.10e}{comma}");
+    }
+    println!("];");
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+fn main() {
+    // log2 mantissa: output crosses zero, use absolute error metric
+    report_strategies(
+        "log2 mantissa (2/2 rational on m-1, abs-error metric)",
+        &[-1.850_383_3e-6, 1.428_716_1, 7.424_587_3e-1],
+        &[9.903_281_4e-1, 1.009_671_8, 1.740_934_3e-1],
+        |m| (1.0 + m).log2(),
+        -0.34,
+        0.34,
+        run_both_strategies(
+            |m| (1.0 + m).log2(),
+            -0.34,
+            0.34,
+            2,
+            2,
+            |m| (1.0 + m).log2(),
+            -0.34,
+            0.34,
+            &[-1.850_383_3e-6, 1.428_716_1, 7.424_587_3e-1],
+            &[9.903_281_4e-1, 1.009_671_8, 1.740_934_3e-1],
+            F32ScoreMetric::AbsoluteError,
+        ),
+        F32ScoreMetric::AbsoluteError,
+    );
+
+    // pow2 fractional: 3/3 standard form
+    report_strategies(
+        "pow2 frac 3/3 (fresh only — libjxl uses non-standard Horner)",
+        &[1.0, 1.0, 1.0, 1.0],
+        &[1.0, 1.0, 1.0, 1.0],
+        |f| 2.0_f64.powf(f),
+        0.0,
+        1.0,
+        {
+            let options = RationalFitOptions {
+                weighting: ErrorWeighting::Relative,
+                n_samples: 10_000,
+                restarts: 4,
+                ..RationalFitOptions::default()
+            };
+            let fit =
+                RationalFit::from_function(|f| 2.0_f64.powf(f), 0.0..=1.0, 3, 3, options).unwrap();
+            let result = fit.as_polynomial().optimize_f32(
+                |f| 2.0_f64.powf(f),
+                0.0_f32,
+                1.0_f32,
+                |v| v,
+                F32SearchConfig {
+                    samples: Some(100_000),
+                    ..F32SearchConfig::default()
+                },
+            );
+            vec![Strategy {
+                label: "fresh fit      ",
+                result,
+            }]
+        },
+        F32ScoreMetric::Ulp,
+    );
+
+    // PQ EOTF small: v in [0.02, 0.25), polynomial input x = v + v²
+    {
+        let lo_v = 0.02_f64;
+        let hi_v = 0.25_f64;
+        let lo_x = lo_v + lo_v * lo_v;
+        let hi_x = hi_v + hi_v * hi_v;
+        let pq_on_x = |x: f64| pq_eotf_exact((-1.0 + (1.0 + 4.0 * x).sqrt()) / 2.0);
+        let cur_p = [
+            4.360_332_03e-10,
+            -1.536_510_77e-07,
+            2.068_641_96e-06,
+            2.803_047_11e-03,
+            1.478_099_48e-02,
+        ];
+        let cur_q = [
+            -9.899_550_22e-03,
+            1.899_117_67,
+            -1.348_280_20,
+            -7.105_475_02e-01,
+            1.0,
+        ];
+
+        report_strategies(
+            "PQ EOTF small (4/4 on v+v\u{00b2}, v \u{2208} [0.02, 0.25))",
+            &cur_p,
+            &cur_q,
+            pq_on_x,
+            lo_x as f32,
+            hi_x as f32,
+            run_both_strategies(
+                pq_on_x,
+                lo_x,
+                hi_x,
+                4,
+                4,
+                pq_on_x,
+                lo_x as f32,
+                hi_x as f32,
+                &cur_p,
+                &cur_q,
+                F32ScoreMetric::Ulp,
+            ),
+            F32ScoreMetric::Ulp,
+        );
+    }
+
+    // PQ EOTF large
+    {
+        let lo_v = 0.25_f64;
+        let hi_v = 1.0_f64;
+        let lo_x = lo_v + lo_v * lo_v;
+        let hi_x = hi_v + hi_v * hi_v;
+        let pq_on_x = |x: f64| pq_eotf_exact((-1.0 + (1.0 + 4.0 * x).sqrt()) / 2.0);
+        let cur_p = [
+            5.430_461_66e-04,
+            -6.310_174_31e-03,
+            2.904_807_34e-01,
+            9.803_630_32e-01,
+            2.228_194_83e-01,
+        ];
+        let cur_q = [
+            1.586_885_61e2,
+            -1.607_640_60e2,
+            6.513_703_72e1,
+            -1.264_383_91e1,
+            1.0,
+        ];
+
+        report_strategies(
+            "PQ EOTF large (4/4 on v+v\u{00b2}, v \u{2208} [0.25, 1.0])",
+            &cur_p,
+            &cur_q,
+            pq_on_x,
+            lo_x as f32,
+            hi_x as f32,
+            run_both_strategies(
+                pq_on_x,
+                lo_x,
+                hi_x,
+                4,
+                4,
+                pq_on_x,
+                lo_x as f32,
+                hi_x as f32,
+                &cur_p,
+                &cur_q,
+                F32ScoreMetric::Ulp,
+            ),
+            F32ScoreMetric::Ulp,
+        );
+    }
+
+    // PQ inverse large
+    {
+        let pq_inv_on_a = |a: f64| pq_inv_exact(a * a * a * a);
+        let lo_a = 1e-4_f64.powf(0.25);
+        let cur_p = [
+            1.351_392e-2,
+            -1.095_778,
+            5.522_776e1,
+            1.492_516e2,
+            4.838_434e1,
+        ];
+        let cur_q = [1.012_416, 2.016_708e1, 9.263_71e1, 1.120_607e2, 2.590_418e1];
+
+        report_strategies(
+            "PQ inverse large (4/4 on v\u{00bc}, v \u{2208} [1e-4, 1.0])",
+            &cur_p,
+            &cur_q,
+            pq_inv_on_a,
+            lo_a as f32,
+            1.0,
+            run_both_strategies(
+                pq_inv_on_a,
+                lo_a,
+                1.0,
+                4,
+                4,
+                pq_inv_on_a,
+                lo_a as f32,
+                1.0,
+                &cur_p,
+                &cur_q,
+                F32ScoreMetric::Ulp,
+            ),
+            F32ScoreMetric::Ulp,
+        );
+    }
+
+    // PQ inverse small
+    {
+        let pq_inv_on_a = |a: f64| pq_inv_exact(a * a * a * a);
+        let lo_a = 1e-7_f64.powf(0.25);
+        let hi_a = 1e-4_f64.powf(0.25);
+        let cur_p = [
+            9.863_406e-6,
+            3.881_234e-1,
+            1.352_821e2,
+            6.889_862e4,
+            -2.864_824e5,
+        ];
+        let cur_q = [
+            3.371_868e1,
+            1.477_719e3,
+            1.608_477e4,
+            -4.389_884e4,
+            -2.072_546e5,
+        ];
+
+        report_strategies(
+            "PQ inverse small (4/4 on v\u{00bc}, v \u{2208} [1e-7, 1e-4))",
+            &cur_p,
+            &cur_q,
+            pq_inv_on_a,
+            lo_a as f32,
+            hi_a as f32,
+            run_both_strategies(
+                pq_inv_on_a,
+                lo_a,
+                hi_a,
+                4,
+                4,
+                pq_inv_on_a,
+                lo_a as f32,
+                hi_a as f32,
+                &cur_p,
+                &cur_q,
+                F32ScoreMetric::Ulp,
+            ),
+            F32ScoreMetric::Ulp,
+        );
+    }
+}

--- a/src/basis/chebyshev.rs
+++ b/src/basis/chebyshev.rs
@@ -162,6 +162,46 @@ impl<T: Value> OrthogonalBasis<T> for ChebyshevBasis<T> {
 }
 
 impl<T: Value> IntoMonomialBasis<T> for ChebyshevBasis<T> {
+    /// Convert from the Chebyshev basis to the monomial basis.
+    ///
+    /// The conversion runs the Chebyshev recurrence
+    /// `T_{k+1}(x') = 2 x' T_k(x') − T_{k-1}(x')` in coefficient space
+    /// (`O(n²)`), then un-normalizes from the basis's internal `x' ∈ [-1, 1]`
+    /// frame back to the caller's `x ∈ [x_min, x_max]` frame.
+    ///
+    /// # Precision warning
+    ///
+    /// Both steps amplify error: the recurrence is well-conditioned in
+    /// `x'`, but the un-normalization is a Vandermonde-style change of
+    /// variable whose condition number scales like
+    /// `((x_max - x_min) / 2)^k` per term — i.e., exponential in both
+    /// degree and domain half-width. The Chebyshev-form polynomial can
+    /// be accurate well past the degree at which its monomial form has
+    /// thrown its accuracy away.
+    ///
+    /// A rough rule of thumb for f64 monomial-form Horner evaluation
+    /// after `as_monomial()`:
+    ///
+    /// | Domain half-width `(x_max - x_min) / 2` | Stable degree | Risky degree (10×+ error vs Chebyshev form) |
+    /// |---:|---:|---:|
+    /// | `≤ 1`   | up to ~25 | ~30+ |
+    /// | `~2`    | up to ~18 | ~22+ |
+    /// | `~6`    | up to ~12 | ~14+ |
+    /// | `~10`   | up to ~10 | ~12+ |
+    /// | `≥ 50`  | up to ~6  | ~8+  |
+    ///
+    /// (Numbers are conservative and depend on the specific reference
+    /// function; widen the domain by a factor of `k` and the safe
+    /// degree drops by roughly `log₂(k)`.)
+    ///
+    /// **If your fit is high degree on a wide domain, do not assume the
+    /// monomial coefficients evaluate as accurately as the Chebyshev
+    /// form.** Validate by spot-checking
+    /// `mono_poly.y(x) - chebyshev_fit.y(x)` on a dense grid before
+    /// shipping. If the gap is wider than the Chebyshev fit's
+    /// max-error-vs-reference, either reduce the degree, narrow the
+    /// domain, evaluate in the Chebyshev form directly, or split the
+    /// domain into piecewise segments.
     fn as_monomial(&self, coefficients: &mut [T]) -> Result<()> {
         let n = coefficients.len() - 1;
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,0 +1,287 @@
+//! Public Horner-form evaluation helpers for fitted polynomials.
+//!
+//! Every caller that ships a polyfit-derived polynomial into a runtime path
+//! ends up writing the same Horner-form evaluator. This module exposes the
+//! canonical implementations so callers can drop them in without
+//! re-implementing the loop (and the off-by-one footguns that come with it).
+//!
+//! Coefficients are always lowest-degree-first (Horner order):
+//! ```text
+//! P(x) = c[0] + c[1]*x + c[2]*x² + ... + c[n]*x^n
+//! ```
+//! This matches the convention used by [`MonomialPolynomial`](crate::MonomialPolynomial),
+//! [`rational::RationalPolynomial`](crate::rational::RationalPolynomial), and
+//! every other coefficient-returning API in this crate.
+//!
+//! # Choosing an evaluator
+//!
+//! - [`horner_f32`] — pure-f32 evaluator. Use when the caller's hot loop is
+//!   f32 end-to-end (e.g., SIMD-vectorized contexts that splat coefficients
+//!   into f32 vector lanes).
+//! - [`horner_f32_via_f64`] — f32 coefficients with f64 accumulator. Use when
+//!   the f32 coefficients came from a polyfit f32-search routine (e.g.,
+//!   [`rational::RationalPolynomial::optimize_f32`](crate::rational::RationalPolynomial::optimize_f32))
+//!   so the evaluator matches the scorer the f32 search used.
+//! - [`horner_f64`] — full f64 evaluator. Use for f64 callers, validation
+//!   passes, or any context where the polynomial is evaluated at high
+//!   precision.
+//! - [`rational_horner_f32_via_f64`] — `P(x)/Q(x)` for f32 coefficients,
+//!   evaluated through an f64 accumulator. Matches
+//!   [`rational::RationalPolynomial::optimize_f32`](crate::rational::RationalPolynomial::optimize_f32)
+//!   so the caller can ship the same evaluation path the f32 search scored
+//!   against.
+//!
+//! # Empty-slice behavior
+//!
+//! All helpers return `0.0` when the coefficient slice is empty. They never
+//! panic on coefficient input. (The `rational_*` helpers will return
+//! `NaN`/`Inf` if the denominator evaluates to zero — same as any explicit
+//! division.)
+//!
+//! # Example
+//!
+//! ```
+//! use polyfit::eval::{horner_f32, horner_f64};
+//!
+//! // Evaluate 1 + 2x + 3x² at x = 2.0 → 1 + 4 + 12 = 17
+//! let coeffs = [1.0_f32, 2.0, 3.0];
+//! assert!((horner_f32(2.0, &coeffs) - 17.0).abs() < 1e-6);
+//!
+//! let coeffs64 = [1.0_f64, 2.0, 3.0];
+//! assert!((horner_f64(2.0, &coeffs64) - 17.0).abs() < 1e-12);
+//! ```
+
+/// Evaluate a polynomial at `x` using Horner's method with f64 precision.
+///
+/// Coefficients are lowest-degree-first: `c[0] + c[1]*x + c[2]*x² + ...`.
+/// Returns `0.0` if `coefficients` is empty.
+///
+/// Uses [`f64::mul_add`] for the accumulator step so the implementation
+/// matches the standard fused-multiply-add Horner pattern (one rounding
+/// per inner step on platforms with hardware FMA).
+#[must_use]
+#[inline]
+pub fn horner_f64(x: f64, coefficients: &[f64]) -> f64 {
+    let Some((&last, rest)) = coefficients.split_last() else {
+        return 0.0;
+    };
+    let mut acc = last;
+    for &c in rest.iter().rev() {
+        acc = acc.mul_add(x, c);
+    }
+    acc
+}
+
+/// Evaluate a polynomial at `x` using Horner's method with pure f32 arithmetic.
+///
+/// Coefficients are lowest-degree-first: `c[0] + c[1]*x + c[2]*x² + ...`.
+/// Returns `0.0` if `coefficients` is empty.
+///
+/// Uses [`f32::mul_add`] for the accumulator step. Use this evaluator when
+/// the caller's hot loop is f32 end-to-end (e.g., a SIMD-vectorized
+/// per-pixel kernel that splats each coefficient into vector lanes).
+///
+/// If the coefficients came from a polyfit f32-search routine that scored
+/// against an f64-accumulator evaluator
+/// (see [`horner_f32_via_f64`] / [`rational_horner_f32_via_f64`]), prefer
+/// the matching evaluator — otherwise the runtime path's rounding will
+/// differ from what the search scored against.
+#[must_use]
+#[inline]
+pub fn horner_f32(x: f32, coefficients: &[f32]) -> f32 {
+    let Some((&last, rest)) = coefficients.split_last() else {
+        return 0.0;
+    };
+    let mut acc = last;
+    for &c in rest.iter().rev() {
+        acc = acc.mul_add(x, c);
+    }
+    acc
+}
+
+/// Evaluate a polynomial with f32 coefficients at `x` using an f64
+/// accumulator, then truncate to f32.
+///
+/// Coefficients are lowest-degree-first: `c[0] + c[1]*x + c[2]*x² + ...`.
+/// Returns `0.0` if `coefficients` is empty.
+///
+/// This matches the evaluation path used internally by
+/// [`rational::RationalPolynomial::optimize_f32`](crate::rational::RationalPolynomial::optimize_f32)
+/// when scoring f32 coefficients during the local search. Use it for the
+/// runtime evaluation when the search produced the coefficients, so the
+/// production path's rounding behavior matches the rounding the f32 search
+/// scored against.
+#[must_use]
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+pub fn horner_f32_via_f64(x: f32, coefficients: &[f32]) -> f32 {
+    let x = f64::from(x);
+    let Some((&last, rest)) = coefficients.split_last() else {
+        return 0.0;
+    };
+    let mut acc = f64::from(last);
+    for &c in rest.iter().rev() {
+        acc = acc.mul_add(x, f64::from(c));
+    }
+    acc as f32
+}
+
+/// Evaluate a rational polynomial `P(x)/Q(x)` with f32 coefficients via
+/// an f64 accumulator, then truncate to f32.
+///
+/// Both `numerator` and `denominator` are lowest-degree-first. Returns
+/// `0.0` if both slices are empty, `NaN`/`Inf` if the denominator
+/// evaluates to zero.
+///
+/// This matches the evaluation path used internally by
+/// [`rational::RationalPolynomial::optimize_f32`](crate::rational::RationalPolynomial::optimize_f32):
+/// the f32 search scores candidates using this exact rounding pattern.
+/// Ship this evaluator in production paths that consume f32-search-derived
+/// rational coefficients, so the production path's f32 output matches the
+/// search's scored output bit-for-bit.
+#[must_use]
+#[inline]
+#[allow(clippy::cast_possible_truncation)]
+pub fn rational_horner_f32_via_f64(x: f32, numerator: &[f32], denominator: &[f32]) -> f32 {
+    let x = f64::from(x);
+    let p = match numerator.split_last() {
+        Some((&last, rest)) => {
+            let mut acc = f64::from(last);
+            for &c in rest.iter().rev() {
+                acc = acc.mul_add(x, f64::from(c));
+            }
+            acc
+        }
+        None => 0.0,
+    };
+    let q = {
+        let Some((&last, rest)) = denominator.split_last() else {
+            return 0.0;
+        };
+        let mut acc = f64::from(last);
+        for &c in rest.iter().rev() {
+            acc = acc.mul_add(x, f64::from(c));
+        }
+        acc
+    };
+    (p / q) as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn horner_f64_matches_naive() {
+        // 1 + 2x + 3x² at x = 2.0 → 1 + 4 + 12 = 17.0
+        let coeffs = [1.0, 2.0, 3.0];
+        assert!((horner_f64(2.0, &coeffs) - 17.0).abs() < 1e-12);
+        // 5 at x = anything → 5
+        assert!((horner_f64(1.5, &[5.0]) - 5.0).abs() < 1e-12);
+        // empty → 0
+        assert_eq!(horner_f64(2.0, &[]).to_bits(), 0.0_f64.to_bits());
+    }
+
+    #[test]
+    fn horner_f32_matches_naive() {
+        let coeffs = [1.0_f32, 2.0, 3.0];
+        assert!((horner_f32(2.0, &coeffs) - 17.0).abs() < 1e-6);
+        assert!((horner_f32(1.5, &[5.0]) - 5.0).abs() < 1e-6);
+        assert_eq!(horner_f32(2.0, &[]).to_bits(), 0.0_f32.to_bits());
+    }
+
+    #[test]
+    fn horner_f32_via_f64_matches_naive() {
+        // For small benign inputs, results match
+        let coeffs = [1.0_f32, 2.0, 3.0];
+        assert!((horner_f32_via_f64(2.0, &coeffs) - 17.0).abs() < 1e-6);
+        assert!((horner_f32_via_f64(1.5, &[5.0]) - 5.0).abs() < 1e-6);
+        assert_eq!(horner_f32_via_f64(2.0, &[]).to_bits(), 0.0_f32.to_bits());
+    }
+
+    #[test]
+    fn rational_horner_f32_via_f64_matches_naive() {
+        // P(x) = 1 + 2x, Q(x) = 1 (constant) → identical to P
+        let p = [1.0_f32, 2.0];
+        let q = [1.0_f32];
+        assert!((rational_horner_f32_via_f64(3.0, &p, &q) - 7.0).abs() < 1e-6);
+
+        // P(x) = x, Q(x) = 1 + x → x / (1 + x)
+        let p = [0.0_f32, 1.0];
+        let q = [1.0_f32, 1.0];
+        let got = rational_horner_f32_via_f64(2.0, &p, &q);
+        assert!((got - (2.0 / 3.0)).abs() < 1e-6);
+
+        // Empty denominator returns 0.0 (defined behavior, not panic)
+        assert_eq!(
+            rational_horner_f32_via_f64(1.0, &[1.0, 2.0], &[]).to_bits(),
+            0.0_f32.to_bits()
+        );
+
+        // Zero denominator → NaN or Inf (defined behavior, not panic)
+        let zero_q = rational_horner_f32_via_f64(0.0, &[1.0_f32], &[0.0_f32]);
+        assert!(zero_q.is_nan() || zero_q.is_infinite());
+    }
+
+    /// `rational_horner_f32_via_f64` MUST match the internal `eval_f32_horner`
+    /// used by `optimize_f32`'s scorer, so callers can ship the public helper
+    /// in production paths and stay bit-identical to what the search scored.
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+    fn rational_horner_matches_internal_optimizer_path() {
+        use crate::rational::{RationalFit, RationalFitOptions};
+
+        let fit = RationalFit::from_function(
+            |x: f64| x.powf(2.4),
+            0.04..=1.0,
+            4,
+            4,
+            RationalFitOptions::default(),
+        )
+        .unwrap();
+
+        let result = fit.as_polynomial().optimize_f32(
+            |x: f64| x.powf(2.4),
+            0.04_f32,
+            1.0_f32,
+            |v| v,
+            crate::rational::F32SearchConfig {
+                samples: Some(1000),
+                ..crate::rational::F32SearchConfig::default()
+            },
+        );
+
+        // Sample a handful of points and verify the public helper produces
+        // the same bits as the internal scorer's evaluator at every one.
+        let lo = f64::from(0.04_f32);
+        let hi = f64::from(1.0_f32);
+        for i in 0..=200 {
+            let x = lo + (hi - lo) * f64::from(i) / 200.0;
+            let x32 = x as f32;
+            let public = rational_horner_f32_via_f64(x32, &result.numerator, &result.denominator);
+
+            // Re-implement the internal helper inline for the parity check
+            let internal = {
+                let xd = f64::from(x32);
+                let mut yp = f64::from(*result.numerator.last().unwrap());
+                for &c in result.numerator[..result.numerator.len() - 1].iter().rev() {
+                    yp = yp.mul_add(xd, f64::from(c));
+                }
+                let mut yq = f64::from(*result.denominator.last().unwrap());
+                for &c in result.denominator[..result.denominator.len() - 1]
+                    .iter()
+                    .rev()
+                {
+                    yq = yq.mul_add(xd, f64::from(c));
+                }
+                (yp / yq) as f32
+            };
+
+            assert_eq!(
+                public.to_bits(),
+                internal.to_bits(),
+                "public eval differs from internal scorer at x={x32}: public={public} internal={internal}",
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,7 @@ pub mod transforms;
 pub mod basis;
 pub mod display;
 pub mod error;
+pub mod eval;
 pub mod rational;
 pub mod score;
 pub mod statistics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,7 @@ pub mod transforms;
 pub mod basis;
 pub mod display;
 pub mod error;
+pub mod rational;
 pub mod score;
 pub mod statistics;
 pub mod value;

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -1,0 +1,2498 @@
+//! Rational polynomial fitting: P(x)/Q(x) approximation.
+//!
+//! Fits a rational polynomial P(x)/Q(x) to data or a known function using
+//! iteratively reweighted least squares (Sanathanan-Koerner iteration).
+//!
+//! Unlike standard polynomial fitting (which is a linear problem), rational
+//! fitting is inherently nonlinear because the denominator coefficients appear
+//! in the divisor. The Sanathanan-Koerner algorithm linearizes this by
+//! iteratively reweighting residuals, converging to the true least-squares
+//! solution.
+//!
+//! # Use cases
+//!
+//! Rational polynomials are particularly good at approximating:
+//! - Transfer functions (sRGB, PQ, HLG)
+//! - Transcendental functions (log₂, exp₂, powf)
+//! - Functions with steep gradients or asymptotic behavior
+//! - Any function where a standard polynomial needs high degree but P/Q needs low degree
+//!
+//! # Coefficient convention
+//!
+//! Coefficients are stored **lowest-degree-first** (Horner order):
+//! ```text
+//! P(x) = p[0] + p[1]*x + p[2]*x² + ... + p[m]*x^m
+//! Q(x) = q[0] + q[1]*x + q[2]*x² + ... + x^n     (monic: leading coeff = 1)
+//! ```
+//!
+//! # Example
+//!
+//! ```rust
+//! use polyfit::rational::{RationalFit, RationalFitOptions};
+//!
+//! // Approximate x^2.4 on [0.04, 1.0] with a 4/4 rational polynomial
+//! let fit = RationalFit::from_function(
+//!     |x: f64| x.powf(2.4),
+//!     0.04..=1.0,
+//!     4, 4,
+//!     RationalFitOptions::default(),
+//! ).unwrap();
+//!
+//! // Evaluate
+//! let y = fit.y(0.5);
+//! assert!((y - 0.5_f64.powf(2.4)).abs() < 1e-6);
+//!
+//! // Get coefficients for use in Horner evaluation
+//! let (p, q) = fit.coefficients();
+//! println!("P: {:?}", p);
+//! println!("Q: {:?}", q);
+//! ```
+//!
+//! # Determinism
+//!
+//! The full pipeline is deterministic: identical input produces identical output.
+//! Sample nodes are Chebyshev-spaced (no RNG), SK/LM iterations are fully
+//! numerical, multi-restart perturbations use `sin`/`cos` of fixed-constant
+//! phases (no RNG), and f32 local search is a deterministic coordinate descent.
+//! No `rand` dependency, no hidden seeds. Coefficient changes must come from
+//! changing the *inputs* (degree, domain, restart count, weight), never the
+//! wall clock.
+//!
+//! # Measurement honesty
+//!
+//! [`F32SearchResult`] records `exhaustive: bool` and `values_scored: u64` so
+//! callers can tell whether reported metrics come from a full f32 sweep or
+//! from uniform sampling. [`piecewise_gap`] measures the ULP gap between a
+//! linear segment and the rational polynomial at their join — different from
+//! the reference-vs-polynomial ULP at the boundary. [`measure_roundtrip`]
+//! measures `f⁻¹(f(v))` error including `u8` and `u16` step counts for
+//! regression gating.
+
+use std::{borrow::Cow, fmt, ops::RangeInclusive};
+
+use nalgebra::{DMatrix, DVector, SVD};
+
+use crate::{
+    error::{Error, Result},
+    value::Value,
+};
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/// A rational polynomial P(x)/Q(x).
+///
+/// Coefficients are lowest-degree-first. The denominator is monic (leading
+/// coefficient = 1).
+#[derive(Debug, Clone, PartialEq)]
+pub struct RationalPolynomial<T: Value = f64> {
+    /// Numerator coefficients: p[0] + p[1]*x + ... + p[m]*x^m
+    numerator: Vec<T>,
+    /// Denominator coefficients: q[0] + q[1]*x + ... + x^n (last element is 1)
+    denominator: Vec<T>,
+}
+
+/// How to weight fitting errors.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ErrorWeighting {
+    /// Minimize sum of |P(x)/Q(x) - y|² (absolute error).
+    #[default]
+    Absolute,
+    /// Minimize sum of |P(x)/Q(x) - y|² / |y|² (relative error).
+    ///
+    /// Better for transfer functions where accuracy matters proportionally.
+    Relative,
+}
+
+/// How constraints are applied across the SK and LM fitting phases.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ConstraintMode {
+    /// Fit entirely unconstrained, then adjust `p[0]` to satisfy each
+    /// constraint exactly via [`RationalPolynomial::snap_boundary`].
+    ///
+    /// Best for piecewise functions (sRGB, PQ) where the join point matters.
+    /// Gives the best overall accuracy because neither SK nor LM is distorted
+    /// by constraint weights. The snap only perturbs `p[0]` (a DC offset),
+    /// which has minimal impact on accuracy — especially when the constraint
+    /// x-value is near zero.
+    #[default]
+    SnapOnly,
+
+    /// Apply constraints during SK initialization only. LM refines freely,
+    /// then `snap_boundary` adjusts `p[0]` to satisfy each constraint exactly.
+    SkThenSnap,
+
+    /// Apply constraints during both SK and LM as weighted residuals.
+    /// Use moderate weights (100-10000) to avoid LM instability.
+    Both,
+
+    /// Apply constraints during SK only, no snap. LM refines freely.
+    /// Boundary accuracy depends on how well SK placed the initial guess.
+    SkOnly,
+}
+
+/// A point constraint: the rational polynomial must pass through (x, y).
+#[derive(Debug, Clone, Copy)]
+pub struct Constraint<T: Value = f64> {
+    /// The x coordinate of the constraint.
+    pub x: T,
+    /// The y value the rational polynomial must match.
+    pub y: T,
+    /// How strongly to enforce (default: 1e6). Higher = harder constraint.
+    pub weight: T,
+}
+
+/// Configuration for rational polynomial fitting.
+#[derive(Debug, Clone)]
+pub struct RationalFitOptions<T: Value = f64> {
+    /// Error weighting strategy.
+    pub weighting: ErrorWeighting,
+    /// Maximum Sanathanan-Koerner iterations (default: 50).
+    pub max_iterations: usize,
+    /// Convergence tolerance on coefficient change (default: 1e-12).
+    pub tolerance: T,
+    /// Point constraints the fit must satisfy.
+    pub constraints: Vec<Constraint<T>>,
+    /// Number of sample points for `from_function` (default: 2000).
+    /// Uses Chebyshev-spaced nodes for stability.
+    pub n_samples: usize,
+    /// Maximum Levenberg-Marquardt refinement iterations after SK converges
+    /// (default: 200). Set to 0 to disable LM refinement and use SK only.
+    pub lm_iterations: usize,
+    /// How constraints are applied across the fitting phases (default: `SnapOnly`).
+    pub constraint_mode: ConstraintMode,
+    /// Number of restarts with perturbed initial conditions (default: 1, no restarts).
+    /// Each restart perturbs the SK result by ~5% deterministic noise, re-runs LM,
+    /// and keeps the best result. Higher values explore more basins at linear cost.
+    pub restarts: usize,
+}
+
+/// Error at a single evaluation point (at or past a domain boundary).
+#[derive(Debug, Clone, Copy)]
+pub struct BoundaryPoint<T: Value = f64> {
+    /// The x coordinate.
+    pub x: T,
+    /// The rational polynomial's output at x.
+    pub predicted: T,
+    /// The reference function's output at x.
+    pub expected: T,
+    /// Absolute error: |predicted - expected|.
+    pub abs_err: T,
+    /// Relative error: |predicted - expected| / |expected|.
+    pub rel_err: T,
+}
+
+/// Error report at and near the domain boundaries.
+///
+/// Contains error at the endpoints (`lo`, `hi`) and at points extrapolated
+/// past the boundary at 0.1%, 1%, 5%, and 10% of the domain width.
+#[derive(Debug, Clone)]
+pub struct BoundaryReport<T: Value = f64> {
+    /// Error at the low endpoint (domain start).
+    pub lo: BoundaryPoint<T>,
+    /// Error at the high endpoint (domain end).
+    pub hi: BoundaryPoint<T>,
+    /// Error at points past the low boundary (0.1%, 1%, 5%, 10% of width).
+    pub past_lo: Vec<BoundaryPoint<T>>,
+    /// Error at points past the high boundary (0.1%, 1%, 5%, 10% of width).
+    pub past_hi: Vec<BoundaryPoint<T>>,
+}
+
+impl<T: Value> fmt::Display for BoundaryReport<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Boundary error:")?;
+        writeln!(
+            f,
+            "  lo (x={:.6e}): abs={:.3e} rel={:.3e}",
+            self.lo.x, self.lo.abs_err, self.lo.rel_err
+        )?;
+        writeln!(
+            f,
+            "  hi (x={:.6e}): abs={:.3e} rel={:.3e}",
+            self.hi.x, self.hi.abs_err, self.hi.rel_err
+        )?;
+
+        if !self.past_lo.is_empty() {
+            writeln!(f, "  Extrapolation past lo:")?;
+            for (i, p) in self.past_lo.iter().enumerate() {
+                let pct = [0.1, 1.0, 5.0, 10.0];
+                let pct_label = pct.get(i).copied().unwrap_or(0.0);
+                writeln!(
+                    f,
+                    "    -{pct_label:>5.1}% (x={:.6e}): abs={:.3e} rel={:.3e}",
+                    p.x, p.abs_err, p.rel_err
+                )?;
+            }
+        }
+        if !self.past_hi.is_empty() {
+            writeln!(f, "  Extrapolation past hi:")?;
+            for (i, p) in self.past_hi.iter().enumerate() {
+                let pct = [0.1, 1.0, 5.0, 10.0];
+                let pct_label = pct.get(i).copied().unwrap_or(0.0);
+                writeln!(
+                    f,
+                    "    +{pct_label:>5.1}% (x={:.6e}): abs={:.3e} rel={:.3e}",
+                    p.x, p.abs_err, p.rel_err
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// How the f32 search scores candidate coefficients.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum F32ScoreMetric {
+    /// Score by ULP distance (best for transfer functions with bounded output).
+    #[default]
+    Ulp,
+    /// Score by absolute error (best when output crosses zero, e.g., log2 mantissa).
+    AbsoluteError,
+}
+
+/// Configuration for f32 coefficient optimization via local search.
+#[derive(Debug, Clone)]
+pub struct F32SearchConfig {
+    /// Search radius per coefficient in f32 ULPs (default: 3).
+    pub radius: i32,
+    /// Maximum search rounds (default: 5).
+    pub max_rounds: usize,
+    /// Scoring metric (default: ULP).
+    pub metric: F32ScoreMetric,
+    /// Number of sample points. `None` = exhaustive sweep of every f32 in the
+    /// domain (default, slow for wide domains). `Some(n)` = uniformly-spaced
+    /// samples (use for domains > 10M f32 values, or transformed inputs).
+    pub samples: Option<usize>,
+}
+
+impl Default for F32SearchConfig {
+    fn default() -> Self {
+        Self {
+            radius: 3,
+            max_rounds: 5,
+            metric: F32ScoreMetric::default(),
+            samples: None,
+        }
+    }
+}
+
+/// Result of f32 coefficient optimization.
+#[derive(Debug, Clone)]
+pub struct F32SearchResult {
+    /// Optimized f32 numerator coefficients.
+    pub numerator: Vec<f32>,
+    /// Optimized f32 denominator coefficients.
+    pub denominator: Vec<f32>,
+    /// Maximum ULP error across the sweep domain.
+    pub max_ulp: u32,
+    /// Average ULP error across the sweep domain.
+    pub avg_ulp: f64,
+    /// ULP error at the domain start (boundary).
+    pub boundary_ulp: u32,
+    /// Number of monotonicity violations.
+    pub mono_violations: u64,
+    /// Maximum absolute error.
+    pub max_abs_err: f64,
+    /// Average absolute error.
+    pub avg_abs_err: f64,
+    /// Number of f32 values scored (exhaustive) or sample count (sampled).
+    pub values_scored: u64,
+    /// `true` if every f32 in the sweep domain was evaluated,
+    /// `false` if uniform sampling was used.
+    pub exhaustive: bool,
+}
+
+impl fmt::Display for F32SearchResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mode = if self.exhaustive {
+            "exhaustive"
+        } else {
+            "sampled"
+        };
+        write!(
+            f,
+            "max_ulp={:>4} avg_ulp={:>7.3} bnd={} mono={} max_abs={:.3e} [{mode}, n={}]",
+            self.max_ulp,
+            self.avg_ulp,
+            self.boundary_ulp,
+            self.mono_violations,
+            self.max_abs_err,
+            self.values_scored,
+        )
+    }
+}
+
+/// A fitted rational polynomial with data and diagnostics.
+#[derive(Debug, Clone)]
+pub struct RationalFit<'data, T: Value = f64> {
+    data: Cow<'data, [(T, T)]>,
+    x_range: RangeInclusive<T>,
+    function: RationalPolynomial<T>,
+    p_degree: usize,
+    q_degree: usize,
+    iterations: usize,
+}
+
+// =============================================================================
+// Defaults
+// =============================================================================
+
+impl Default for RationalFitOptions<f64> {
+    fn default() -> Self {
+        Self {
+            weighting: ErrorWeighting::Absolute,
+            max_iterations: 50,
+            tolerance: 1e-12,
+            constraints: Vec::new(),
+            n_samples: 2000,
+            lm_iterations: 200,
+            constraint_mode: ConstraintMode::default(),
+            restarts: 1,
+        }
+    }
+}
+
+impl Default for RationalFitOptions<f32> {
+    fn default() -> Self {
+        Self {
+            weighting: ErrorWeighting::Absolute,
+            max_iterations: 50,
+            tolerance: 1e-7,
+            constraints: Vec::new(),
+            n_samples: 2000,
+            lm_iterations: 200,
+            constraint_mode: ConstraintMode::default(),
+            restarts: 1,
+        }
+    }
+}
+
+impl<T: Value> Constraint<T> {
+    /// Create a hard constraint at (x, y) with default weight 1e6.
+    pub fn new(x: T, y: T) -> Self {
+        Self {
+            x,
+            y,
+            weight: T::try_cast(1_000_000.0).unwrap_or(T::one()),
+        }
+    }
+
+    /// Create a constraint with custom weight.
+    pub fn with_weight(x: T, y: T, weight: T) -> Self {
+        Self { x, y, weight }
+    }
+}
+
+// =============================================================================
+// RationalPolynomial evaluation
+// =============================================================================
+
+impl<T: Value> RationalPolynomial<T> {
+    /// Create a rational polynomial from numerator and denominator coefficients.
+    ///
+    /// Both are lowest-degree-first. The denominator's last element should be 1
+    /// (monic convention).
+    #[must_use]
+    pub fn new(numerator: Vec<T>, denominator: Vec<T>) -> Self {
+        Self {
+            numerator,
+            denominator,
+        }
+    }
+
+    /// Evaluate `P(x)/Q(x)` using Horner's method.
+    #[inline]
+    #[must_use]
+    pub fn y(&self, x: T) -> T {
+        horner(&self.numerator, x) / horner(&self.denominator, x)
+    }
+
+    /// Numerator coefficients (lowest-degree-first).
+    #[must_use]
+    pub fn numerator(&self) -> &[T] {
+        &self.numerator
+    }
+
+    /// Denominator coefficients (lowest-degree-first, last = 1.0).
+    #[must_use]
+    pub fn denominator(&self) -> &[T] {
+        &self.denominator
+    }
+
+    /// Numerator and denominator as a pair.
+    #[must_use]
+    pub fn coefficients(&self) -> (&[T], &[T]) {
+        (&self.numerator, &self.denominator)
+    }
+
+    /// Numerator degree.
+    #[must_use]
+    pub fn numerator_degree(&self) -> usize {
+        self.numerator.len().saturating_sub(1)
+    }
+
+    /// Denominator degree.
+    #[must_use]
+    pub fn denominator_degree(&self) -> usize {
+        self.denominator.len().saturating_sub(1)
+    }
+
+    /// Adjust the numerator constant term (`p[0]`) so that `P(x)/Q(x) = y` exactly.
+    ///
+    /// This is a post-hoc boundary snap: after fitting unconstrained for best
+    /// overall accuracy, call this to nail the piecewise join point. Since `p[0]`
+    /// is a DC offset, the perturbation has minimal impact on accuracy elsewhere —
+    /// especially when `x` is small (as it is for sRGB/PQ thresholds near zero).
+    ///
+    /// For f32 coefficients evaluated via f64 Horner, truncate each coefficient
+    /// to f32 **before** calling this, so the snap accounts for truncation error.
+    pub fn snap_boundary(&mut self, x: T, y: T) {
+        // P(x) = p[0] + x * (p[1] + x * (p[2] + ...))
+        // We want P(x)/Q(x) = y  =>  p[0] = y * Q(x) - x * horner(p[1..], x)
+        let q_at_x = horner(&self.denominator, x);
+        let p_rest = if self.numerator.len() > 1 {
+            x * horner(&self.numerator[1..], x)
+        } else {
+            T::zero()
+        };
+        self.numerator[0] = y * q_at_x - p_rest;
+    }
+}
+
+impl RationalPolynomial<f64> {
+    /// Truncate to f32 and locally search for the best f32 coefficients.
+    ///
+    /// This is the final optimization step for transfer function approximations:
+    /// the f64 fit finds the right basin, truncation to f32 introduces rounding,
+    /// and this search explores ±`radius` f32 ULP perturbations per coefficient
+    /// to find the f32 combination with lowest error.
+    ///
+    /// The `transform` maps domain values to polynomial input (e.g., `|v| v.sqrt()`
+    /// for L2S which evaluates the polynomial on √x). Pass `|v| v` for identity.
+    ///
+    /// Evaluation uses f64-intermediate Horner (matching linear-srgb's scalar path).
+    /// For different evaluation semantics, use the coefficients from this result
+    /// with your own search.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_lossless,
+        clippy::needless_pass_by_value
+    )]
+    pub fn optimize_f32(
+        &self,
+        reference: impl Fn(f64) -> f64,
+        sweep_lo: f32,
+        sweep_hi: f32,
+        transform: impl Fn(f32) -> f32,
+        config: F32SearchConfig,
+    ) -> F32SearchResult {
+        let p: Vec<f32> = self.numerator.iter().map(|&c| c as f32).collect();
+        let q: Vec<f32> = self.denominator.iter().map(|&c| c as f32).collect();
+        f32_local_search(&p, &q, &reference, sweep_lo, sweep_hi, &transform, &config)
+    }
+
+    /// Warm-start f32 optimization from existing f32 coefficients.
+    ///
+    /// Promotes to f64, runs LM refinement, truncates back to f32, then runs
+    /// the local f32 search. Use this when you already have good coefficients
+    /// and want to explore nearby basins.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_lossless,
+        clippy::needless_pass_by_value,
+        clippy::too_many_arguments
+    )]
+    pub fn refine_from_f32(
+        existing_p: &[f32],
+        existing_q: &[f32],
+        reference: impl Fn(f64) -> f64,
+        data: &[(f64, f64)],
+        sweep_lo: f32,
+        sweep_hi: f32,
+        transform: impl Fn(f32) -> f32,
+        config: F32SearchConfig,
+        weighting: ErrorWeighting,
+        lm_iters: usize,
+    ) -> F32SearchResult {
+        // Promote to f64
+        let mut poly = RationalPolynomial::new(
+            existing_p.iter().map(|&c| f64::from(c)).collect(),
+            existing_q.iter().map(|&c| f64::from(c)).collect(),
+        );
+
+        // Run LM refinement on f64
+        refine_lm(&mut poly, data, &[], weighting, lm_iters, 1e-15);
+
+        // Truncate to f32 and run local search
+        let p: Vec<f32> = poly.numerator.iter().map(|&c| c as f32).collect();
+        let q: Vec<f32> = poly.denominator.iter().map(|&c| c as f32).collect();
+        f32_local_search(&p, &q, &reference, sweep_lo, sweep_hi, &transform, &config)
+    }
+}
+
+/// Measure the f32-ULP gap at a piecewise join point.
+///
+/// Piecewise transfer functions (sRGB, PQ, HLG) have a threshold where the
+/// polynomial meets a linear segment. The *practical* continuity metric is
+/// `ulp_distance(linear_segment(threshold - 1 ULP), polynomial(threshold + 1 ULP))`
+/// — the gap between the two branches at adjacent f32 values.
+///
+/// This differs from `F32SearchResult::boundary_ulp` (which measures the
+/// polynomial's error against the reference function at the threshold). A fit
+/// that's close to the reference at the threshold can still produce a visible
+/// discontinuity if the linear segment rounds differently from the polynomial.
+///
+/// # Parameters
+/// - `threshold`: the f32 input at which the two branches meet
+/// - `poly_p`, `poly_q`: the rational polynomial's f32 coefficients
+/// - `linear_branch`: the linear segment (e.g., `|v| v / 12.92`)
+/// - `poly_input_transform`: maps the threshold value to polynomial input
+///   (use `|v| v` for identity, `|v| v.sqrt()` for L2S)
+#[must_use]
+#[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+pub fn piecewise_gap(
+    threshold: f32,
+    poly_p: &[f32],
+    poly_q: &[f32],
+    linear_branch: impl Fn(f32) -> f32,
+    poly_input_transform: impl Fn(f32) -> f32,
+) -> u32 {
+    let below = f32::from_bits(threshold.to_bits() - 1);
+    let above = f32::from_bits(threshold.to_bits() + 1);
+    let left = linear_branch(below);
+    let right = eval_f32_horner(poly_input_transform(above), poly_p, poly_q);
+    f32_ulp_distance(left, right)
+}
+
+/// Report of composed-function error (roundtrip).
+///
+/// When two polynomials approximate inverse functions `f` and `f⁻¹`,
+/// the composed roundtrip `f⁻¹(f(v))` should return `v`. This measures
+/// how well that holds across a sweep domain.
+#[derive(Debug, Clone)]
+pub struct RoundtripReport {
+    /// Maximum absolute error: `|f⁻¹(f(v)) - v|` across the sweep domain.
+    pub max_abs_err: f64,
+    /// Average absolute error.
+    pub avg_abs_err: f64,
+    /// Maximum ULP distance between roundtrip output and input.
+    pub max_ulp: u32,
+    /// Number of inputs where roundtrip error exceeds 1/65535 (one u16 step).
+    pub u16_over_1: u64,
+    /// Number of inputs where roundtrip error exceeds 0.5/255 (half u8 step).
+    pub u8_over_half: u64,
+    /// Number of f32 values scored.
+    pub values_scored: u64,
+    /// True if every f32 in the sweep domain was evaluated.
+    pub exhaustive: bool,
+}
+
+impl fmt::Display for RoundtripReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mode = if self.exhaustive {
+            "exhaustive"
+        } else {
+            "sampled"
+        };
+        write!(
+            f,
+            "max_ulp={} max_abs={:.3e} avg_abs={:.3e} u16>1={} u8>0.5={} [{mode}, n={}]",
+            self.max_ulp,
+            self.max_abs_err,
+            self.avg_abs_err,
+            self.u16_over_1,
+            self.u8_over_half,
+            self.values_scored,
+        )
+    }
+}
+
+/// Measure roundtrip error of `f⁻¹(f(v))` across a sweep domain.
+///
+/// Each of `forward` and `inverse` is a closure that maps f32→f32, typically
+/// a piecewise function combining a polynomial with linear segments and clamps.
+/// The implementation is opaque to `measure_roundtrip` — pass whatever composition
+/// matches your production evaluation path.
+///
+/// # Parameters
+/// - `forward`: the f(v) function (e.g., `|v| srgb_to_linear_fast(v)`)
+/// - `inverse`: the f⁻¹(u) function (e.g., `|u| linear_to_srgb_fast(u)`)
+/// - `sweep_lo`, `sweep_hi`: f32 range to sweep
+/// - `samples`: `None` = exhaustive f32 sweep, `Some(n)` = n uniform samples
+#[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+pub fn measure_roundtrip(
+    forward: impl Fn(f32) -> f32,
+    inverse: impl Fn(f32) -> f32,
+    sweep_lo: f32,
+    sweep_hi: f32,
+    samples: Option<usize>,
+) -> RoundtripReport {
+    const U16_STEP: f64 = 1.0 / 65535.0;
+    const U8_HALF: f64 = 0.5 / 255.0;
+
+    let mut max_ulp = 0u32;
+    let mut max_abs: f64 = 0.0;
+    let mut sum_abs: f64 = 0.0;
+    let mut u16_over = 0u64;
+    let mut u8_over = 0u64;
+    let mut count = 0u64;
+
+    let mut eval_at = |v: f32| {
+        let rt = inverse(forward(v));
+        let abs_err = (f64::from(rt) - f64::from(v)).abs();
+        let ulp = f32_ulp_distance(rt, v);
+        if ulp > max_ulp {
+            max_ulp = ulp;
+        }
+        if abs_err > max_abs {
+            max_abs = abs_err;
+        }
+        sum_abs += abs_err;
+        if abs_err > U16_STEP {
+            u16_over += 1;
+        }
+        if abs_err > U8_HALF {
+            u8_over += 1;
+        }
+        count += 1;
+    };
+
+    if let Some(n) = samples {
+        let lo = f64::from(sweep_lo);
+        let hi = f64::from(sweep_hi);
+        for i in 0..=n {
+            let v = lo + (hi - lo) * i as f64 / n as f64;
+            eval_at(v as f32);
+        }
+    } else {
+        let mut v = sweep_lo;
+        while v <= sweep_hi {
+            eval_at(v);
+            v = f32_next(v);
+        }
+    }
+
+    RoundtripReport {
+        max_abs_err: max_abs,
+        avg_abs_err: sum_abs / count.max(1) as f64,
+        max_ulp,
+        u16_over_1: u16_over,
+        u8_over_half: u8_over,
+        values_scored: count,
+        exhaustive: samples.is_none(),
+    }
+}
+
+/// Core f32 local search — shared by `optimize_f32` and `refine_from_f32`.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_lossless,
+    clippy::too_many_lines
+)]
+fn f32_local_search(
+    initial_p: &[f32],
+    initial_q: &[f32],
+    reference: &dyn Fn(f64) -> f64,
+    sweep_lo: f32,
+    sweep_hi: f32,
+    transform: &dyn Fn(f32) -> f32,
+    config: &F32SearchConfig,
+) -> F32SearchResult {
+    let mut p = initial_p.to_vec();
+    let mut q = initial_q.to_vec();
+
+    // Score: (primary, secondary, avg, mono)
+    // For ULP: primary = max_ulp, secondary = boundary_ulp
+    // For AbsError: primary = max_abs as u64 bits, secondary = boundary_ulp
+    let score = |p: &[f32], q: &[f32]| -> (u64, u64, f64, u64) {
+        let mut max_ulp = 0u32;
+        let mut sum_ulp = 0u64;
+        let mut max_abs: f64 = 0.0;
+        let mut sum_abs: f64 = 0.0;
+        let mut count = 0u64;
+        let mut mono = 0u64;
+        let mut prev = eval_f32_horner(transform(sweep_lo), p, q);
+
+        let mut eval_at = |x_f32: f32, x_f64: f64| {
+            let got = eval_f32_horner(transform(x_f32), p, q);
+            let expected = reference(x_f64) as f32;
+            let ulp = f32_ulp_distance(got, expected);
+            let abs_err = (f64::from(got) - f64::from(expected)).abs();
+            if ulp > max_ulp {
+                max_ulp = ulp;
+            }
+            if abs_err > max_abs {
+                max_abs = abs_err;
+            }
+            sum_ulp += u64::from(ulp);
+            sum_abs += abs_err;
+            count += 1;
+            if count > 1 && got < prev {
+                mono += 1;
+            }
+            prev = got;
+        };
+
+        if let Some(n) = config.samples {
+            let lo = f64::from(sweep_lo);
+            let hi = f64::from(sweep_hi);
+            for i in 0..=n {
+                let x = lo + (hi - lo) * i as f64 / n as f64;
+                eval_at(x as f32, x);
+            }
+        } else {
+            let mut v = sweep_lo;
+            while v <= sweep_hi {
+                eval_at(v, f64::from(v));
+                v = f32_next(v);
+            }
+        }
+
+        let bnd_ulp = f32_ulp_distance(
+            eval_f32_horner(transform(sweep_lo), p, q),
+            reference(f64::from(sweep_lo)) as f32,
+        );
+        match config.metric {
+            F32ScoreMetric::Ulp => (
+                u64::from(max_ulp),
+                u64::from(bnd_ulp),
+                sum_ulp as f64 / count.max(1) as f64,
+                mono,
+            ),
+            F32ScoreMetric::AbsoluteError => (
+                max_abs.to_bits(),
+                u64::from(bnd_ulp),
+                sum_abs / count.max(1) as f64,
+                mono,
+            ),
+        }
+    };
+
+    let is_better = |a: (u64, u64, f64, u64), b: (u64, u64, f64, u64)| -> bool {
+        if a.3 > 0 && b.3 == 0 {
+            return false;
+        }
+        if a.3 == 0 && b.3 > 0 {
+            return true;
+        }
+        (a.0, a.1) < (b.0, b.1) || ((a.0, a.1) == (b.0, b.1) && a.2 < b.2)
+    };
+
+    let mut best = score(&p, &q);
+    let n_coeffs = p.len() + q.len() - 1;
+
+    for _round in 0..config.max_rounds {
+        let mut improved = false;
+        for ci in 0..n_coeffs {
+            let is_p = ci < p.len();
+            let idx = if is_p { ci } else { ci - p.len() };
+            let original = if is_p { p[idx] } else { q[idx] };
+
+            let mut best_delta = 0i32;
+            let mut best_delta_score: Option<(u64, u64, f64, u64)> = None;
+
+            for delta in (-config.radius..=config.radius).filter(|&d| d != 0) {
+                let nudged = f32_nudge(original, delta);
+                if is_p {
+                    p[idx] = nudged;
+                } else {
+                    q[idx] = nudged;
+                }
+                let s = score(&p, &q);
+                let dominated = best_delta_score
+                    .as_ref()
+                    .is_some_and(|bs| !is_better(s, *bs));
+                if is_better(s, best) && !dominated {
+                    best_delta = delta;
+                    best_delta_score = Some(s);
+                }
+                if is_p {
+                    p[idx] = original;
+                } else {
+                    q[idx] = original;
+                }
+            }
+
+            if let Some(s) = best_delta_score {
+                let nudged = f32_nudge(original, best_delta);
+                if is_p {
+                    p[idx] = nudged;
+                } else {
+                    q[idx] = nudged;
+                }
+                best = s;
+                improved = true;
+            }
+        }
+        if !improved {
+            break;
+        }
+    }
+
+    // Final full measurement for reporting (always compute both metrics)
+    let mut max_ulp = 0u32;
+    let mut sum_ulp = 0u64;
+    let mut max_abs: f64 = 0.0;
+    let mut sum_abs: f64 = 0.0;
+    let mut count = 0u64;
+    let mut mono = 0u64;
+    let mut prev = eval_f32_horner(transform(sweep_lo), &p, &q);
+    let mut final_eval = |x_f32: f32, x_f64: f64| {
+        let got = eval_f32_horner(transform(x_f32), &p, &q);
+        let expected = reference(x_f64) as f32;
+        let ulp = f32_ulp_distance(got, expected);
+        let abs_err = (f64::from(got) - f64::from(expected)).abs();
+        if ulp > max_ulp {
+            max_ulp = ulp;
+        }
+        if abs_err > max_abs {
+            max_abs = abs_err;
+        }
+        sum_ulp += u64::from(ulp);
+        sum_abs += abs_err;
+        count += 1;
+        if count > 1 && got < prev {
+            mono += 1;
+        }
+        prev = got;
+    };
+    if let Some(n) = config.samples {
+        let lo = f64::from(sweep_lo);
+        let hi = f64::from(sweep_hi);
+        for i in 0..=n {
+            let x = lo + (hi - lo) * i as f64 / n as f64;
+            final_eval(x as f32, x);
+        }
+    } else {
+        let mut v = sweep_lo;
+        while v <= sweep_hi {
+            final_eval(v, f64::from(v));
+            v = f32_next(v);
+        }
+    }
+    let bnd = f32_ulp_distance(
+        eval_f32_horner(transform(sweep_lo), &p, &q),
+        reference(f64::from(sweep_lo)) as f32,
+    );
+
+    F32SearchResult {
+        numerator: p,
+        denominator: q,
+        max_ulp,
+        avg_ulp: sum_ulp as f64 / count.max(1) as f64,
+        boundary_ulp: bnd,
+        mono_violations: mono,
+        max_abs_err: max_abs,
+        avg_abs_err: sum_abs / count.max(1) as f64,
+        values_scored: count,
+        exhaustive: config.samples.is_none(),
+    }
+}
+
+// =============================================================================
+// RationalFit — public API
+// =============================================================================
+
+impl<'data, T: Value> RationalFit<'data, T> {
+    /// Fit a rational polynomial P(x)/Q(x) to data.
+    ///
+    /// # Parameters
+    /// - `data`: (x, y) pairs
+    /// - `p_degree`: degree of numerator P
+    /// - `q_degree`: degree of denominator Q
+    /// - `options`: fitting configuration (weighting, constraints, iterations)
+    ///
+    /// # Errors
+    /// Returns an error if the data is empty, degrees are too high for the data,
+    /// or the SVD solver fails to converge.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new(
+        data: impl Into<Cow<'data, [(T, T)]>>,
+        p_degree: usize,
+        q_degree: usize,
+        options: RationalFitOptions<T>,
+    ) -> Result<Self> {
+        let data = data.into();
+        if data.is_empty() {
+            return Err(Error::NoData);
+        }
+
+        let p_terms = p_degree + 1;
+        let q_terms = q_degree + 1; // includes the fixed leading 1
+        let total_free = p_terms + q_degree; // q_degree free params (leading 1 is fixed)
+
+        if data.len() < total_free {
+            return Err(Error::DegreeTooHigh(p_degree.max(q_degree)));
+        }
+
+        let x_min = data.iter().map(|(x, _)| *x).fold(T::infinity(), Value::min);
+        let x_max = data
+            .iter()
+            .map(|(x, _)| *x)
+            .fold(T::neg_infinity(), Value::max);
+        let x_range = x_min..=x_max;
+
+        let (poly, iterations) = fit_rational(
+            &data,
+            p_terms,
+            q_terms,
+            options.max_iterations,
+            options.lm_iterations,
+            options.tolerance,
+            &options.constraints,
+            options.weighting,
+            options.constraint_mode,
+            options.restarts,
+        )?;
+
+        Ok(Self {
+            data,
+            x_range,
+            function: poly,
+            p_degree,
+            q_degree,
+            iterations,
+        })
+    }
+
+    /// Fit a rational polynomial to a known function sampled on a domain.
+    ///
+    /// Generates Chebyshev-spaced sample points for near-minimax conditioning.
+    ///
+    /// # Parameters
+    /// - `f`: the target function
+    /// - `domain`: closed interval \[a, b\] to fit over
+    /// - `p_degree`: degree of numerator P
+    /// - `q_degree`: degree of denominator Q
+    /// - `options`: fitting configuration
+    ///
+    /// # Errors
+    /// Returns an error if degrees are too high for the sample count,
+    /// or the SVD solver fails to converge.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn from_function(
+        f: impl Fn(T) -> T,
+        domain: RangeInclusive<T>,
+        p_degree: usize,
+        q_degree: usize,
+        options: RationalFitOptions<T>,
+    ) -> Result<RationalFit<'static, T>> {
+        let a = *domain.start();
+        let b = *domain.end();
+        let n = options.n_samples;
+
+        let data: Vec<(T, T)> = chebyshev_nodes(n, a, b)
+            .into_iter()
+            .map(|x| (x, f(x)))
+            .collect();
+
+        let p_terms = p_degree + 1;
+        let q_terms = q_degree + 1;
+
+        if data.len() < p_terms + q_degree {
+            return Err(Error::DegreeTooHigh(p_degree.max(q_degree)));
+        }
+
+        let (poly, iterations) = fit_rational(
+            &data,
+            p_terms,
+            q_terms,
+            options.max_iterations,
+            options.lm_iterations,
+            options.tolerance,
+            &options.constraints,
+            options.weighting,
+            options.constraint_mode,
+            options.restarts,
+        )?;
+
+        Ok(RationalFit {
+            data: Cow::Owned(data),
+            x_range: a..=b,
+            function: poly,
+            p_degree,
+            q_degree,
+            iterations,
+        })
+    }
+
+    /// Evaluate the fitted rational polynomial at x.
+    #[inline]
+    #[must_use]
+    pub fn y(&self, x: T) -> T {
+        self.function.y(x)
+    }
+
+    /// The underlying rational polynomial.
+    #[must_use]
+    pub fn as_polynomial(&self) -> &RationalPolynomial<T> {
+        &self.function
+    }
+
+    /// Numerator and denominator coefficients (lowest-degree-first).
+    #[must_use]
+    pub fn coefficients(&self) -> (&[T], &[T]) {
+        self.function.coefficients()
+    }
+
+    /// The degree of the numerator.
+    #[must_use]
+    pub fn p_degree(&self) -> usize {
+        self.p_degree
+    }
+
+    /// The degree of the denominator.
+    #[must_use]
+    pub fn q_degree(&self) -> usize {
+        self.q_degree
+    }
+
+    /// How many Sanathanan-Koerner iterations were used.
+    #[must_use]
+    pub fn iterations(&self) -> usize {
+        self.iterations
+    }
+
+    /// The x-range of the fitted data.
+    #[must_use]
+    pub fn x_range(&self) -> &RangeInclusive<T> {
+        &self.x_range
+    }
+
+    /// The data used for fitting.
+    #[must_use]
+    pub fn data(&self) -> &[(T, T)] {
+        &self.data
+    }
+
+    /// Coefficient of determination R².
+    ///
+    /// Values near 1.0 indicate a good fit.
+    #[must_use]
+    pub fn r_squared(&self) -> T {
+        let n = self.data.len();
+        if n == 0 {
+            return T::zero();
+        }
+
+        let y_mean = self
+            .data
+            .iter()
+            .map(|(_, y)| *y)
+            .fold(T::zero(), |a, b| a + b)
+            / T::try_cast(n).unwrap_or(T::one());
+
+        let ss_tot = self
+            .data
+            .iter()
+            .map(|(_, y)| {
+                let d = *y - y_mean;
+                d * d
+            })
+            .fold(T::zero(), |a, b| a + b);
+
+        let ss_res = self
+            .data
+            .iter()
+            .map(|(x, y)| {
+                let d = self.function.y(*x) - *y;
+                d * d
+            })
+            .fold(T::zero(), |a, b| a + b);
+
+        if ss_tot.is_near_zero() {
+            T::one()
+        } else {
+            T::one() - ss_res / ss_tot
+        }
+    }
+
+    /// Maximum absolute error across all data points.
+    #[must_use]
+    pub fn max_abs_error(&self) -> T {
+        self.data
+            .iter()
+            .map(|(x, y)| Value::abs(self.function.y(*x) - *y))
+            .fold(T::zero(), Value::max)
+    }
+
+    /// Maximum relative error across all data points.
+    ///
+    /// Relative error is `|predicted - actual| / |actual|`.
+    /// Points where `|actual|` < epsilon are skipped.
+    #[must_use]
+    pub fn max_rel_error(&self) -> T {
+        self.data
+            .iter()
+            .filter_map(|(x, y)| {
+                let ay = Value::abs(*y);
+                if ay.is_near_zero() {
+                    return None;
+                }
+                Some(Value::abs(self.function.y(*x) - *y) / ay)
+            })
+            .fold(T::zero(), Value::max)
+    }
+
+    /// Residuals: predicted - actual for each data point.
+    #[must_use]
+    pub fn residuals(&self) -> Vec<T> {
+        self.data
+            .iter()
+            .map(|(x, y)| self.function.y(*x) - *y)
+            .collect()
+    }
+
+    /// Error at and near the domain boundaries.
+    ///
+    /// For piecewise functions (sRGB, PQ), the domain start is where the
+    /// rational polynomial joins another segment. This method reports
+    /// absolute and relative error at both endpoints, plus extrapolation
+    /// error at small offsets past the boundary.
+    ///
+    /// The `reference` function provides ground-truth values for evaluation
+    /// points at and beyond the fitted domain.
+    #[must_use]
+    pub fn boundary_error(&self, reference: impl Fn(T) -> T) -> BoundaryReport<T> {
+        let lo = *self.x_range.start();
+        let hi = *self.x_range.end();
+        let width = hi - lo;
+
+        let eval_point = |x: T| -> BoundaryPoint<T> {
+            let predicted = self.function.y(x);
+            let expected = reference(x);
+            let abs_err = Value::abs(predicted - expected);
+            let rel_err = if Value::abs(expected).is_near_zero() {
+                abs_err
+            } else {
+                abs_err / Value::abs(expected)
+            };
+            BoundaryPoint {
+                x,
+                predicted,
+                expected,
+                abs_err,
+                rel_err,
+            }
+        };
+
+        // Sample at the endpoints
+        let at_lo = eval_point(lo);
+        let at_hi = eval_point(hi);
+
+        // Extrapolation past boundaries: 0.1%, 1%, 5%, 10% of domain width
+        let fractions = [
+            T::try_cast(0.001).unwrap_or(T::zero()),
+            T::try_cast(0.01).unwrap_or(T::zero()),
+            T::try_cast(0.05).unwrap_or(T::zero()),
+            T::try_cast(0.1).unwrap_or(T::zero()),
+        ];
+        let past_lo: Vec<BoundaryPoint<T>> = fractions
+            .iter()
+            .map(|&f| eval_point(lo - width * f))
+            .collect();
+        let past_hi: Vec<BoundaryPoint<T>> = fractions
+            .iter()
+            .map(|&f| eval_point(hi + width * f))
+            .collect();
+
+        BoundaryReport {
+            lo: at_lo,
+            hi: at_hi,
+            past_lo,
+            past_hi,
+        }
+    }
+
+    /// Returns an owned version of this fit.
+    #[must_use]
+    pub fn to_owned(&self) -> RationalFit<'static, T> {
+        RationalFit {
+            data: Cow::Owned(self.data.to_vec()),
+            x_range: self.x_range.clone(),
+            function: self.function.clone(),
+            p_degree: self.p_degree,
+            q_degree: self.q_degree,
+            iterations: self.iterations,
+        }
+    }
+}
+
+// =============================================================================
+// Display
+// =============================================================================
+
+impl<T: Value> fmt::Display for RationalPolynomial<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(")?;
+        write_poly_terms(f, &self.numerator)?;
+        write!(f, ") / (")?;
+        write_poly_terms(f, &self.denominator)?;
+        write!(f, ")")
+    }
+}
+
+impl<T: Value> fmt::Display for RationalFit<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RationalFit {}/{} (R²={:.6}, {} iters): {}",
+            self.p_degree,
+            self.q_degree,
+            self.r_squared(),
+            self.iterations,
+            self.function,
+        )
+    }
+}
+
+fn write_poly_terms<T: Value>(f: &mut fmt::Formatter<'_>, coeffs: &[T]) -> fmt::Result {
+    let mut first = true;
+    for (i, c) in coeffs.iter().enumerate() {
+        if !first {
+            write!(f, " + ")?;
+        }
+        first = false;
+        match i {
+            0 => write!(f, "{c:.6e}")?,
+            1 => write!(f, "{c:.6e}*x")?,
+            _ => write!(f, "{c:.6e}*x^{i}")?,
+        }
+    }
+    Ok(())
+}
+
+// =============================================================================
+// Horner evaluation
+// =============================================================================
+
+/// Evaluate a polynomial using Horner's method.
+/// Coefficients are lowest-degree-first: c[0] + c[1]*x + c[2]*x² + ...
+#[inline(always)]
+fn horner<T: Value>(coeffs: &[T], x: T) -> T {
+    let mut result = coeffs[coeffs.len() - 1];
+    for i in (0..coeffs.len() - 1).rev() {
+        result = result * x + coeffs[i];
+    }
+    result
+}
+
+// =============================================================================
+// f32 helpers for optimize_f32
+// =============================================================================
+
+/// Evaluate rational polynomial with f32 coefficients via f64 Horner.
+/// Matches the evaluation path in linear-srgb's scalar implementation.
+#[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+fn eval_f32_horner(x: f32, p: &[f32], q: &[f32]) -> f32 {
+    let x = x as f64;
+    let mut yp = *p.last().unwrap() as f64;
+    for &c in p[..p.len() - 1].iter().rev() {
+        yp = yp.mul_add(x, c as f64);
+    }
+    let mut yq = *q.last().unwrap() as f64;
+    for &c in q[..q.len() - 1].iter().rev() {
+        yq = yq.mul_add(x, c as f64);
+    }
+    (yp / yq) as f32
+}
+
+/// ULP distance between two f32 values, handling sign correctly.
+///
+/// Maps negative floats through zero so the integer representation
+/// is monotonic across the entire f32 range (including sign crossings).
+#[allow(clippy::float_cmp, clippy::cast_possible_wrap)]
+fn f32_ulp_distance(a: f32, b: f32) -> u32 {
+    if a == b {
+        return 0;
+    }
+    if a.is_nan() || b.is_nan() {
+        return u32::MAX;
+    }
+    // Map to linear integer space: negate and flip negative floats
+    // so that the integer representation is monotonic across zero.
+    let ai = {
+        let bits = a.to_bits() as i32;
+        if bits < 0 {
+            i32::MIN - bits
+        } else {
+            bits
+        }
+    };
+    let bi = {
+        let bits = b.to_bits() as i32;
+        if bits < 0 {
+            i32::MIN - bits
+        } else {
+            bits
+        }
+    };
+    #[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+    {
+        (i64::from(ai) - i64::from(bi)).unsigned_abs() as u32
+    }
+}
+
+/// Next representable f32 toward +infinity, handling negative values correctly.
+fn f32_next(v: f32) -> f32 {
+    if v.is_nan() || v >= f32::MAX {
+        return v;
+    }
+    if v == 0.0 {
+        return f32::from_bits(1);
+    } // +0 → smallest positive
+    if v > 0.0 {
+        f32::from_bits(v.to_bits() + 1)
+    } else {
+        // Negative: decrement bit pattern to move toward zero
+        f32::from_bits(v.to_bits() - 1)
+    }
+}
+
+/// Nudge an f32 by `delta` ULPs.
+#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+fn f32_nudge(v: f32, delta: i32) -> f32 {
+    f32::from_bits((v.to_bits() as i32 + delta) as u32)
+}
+
+// =============================================================================
+// Chebyshev nodes
+// =============================================================================
+
+/// Generate n Chebyshev-spaced nodes on \[a, b\].
+///
+/// Chebyshev nodes cluster near endpoints, reducing Runge's phenomenon and
+/// improving conditioning for polynomial fitting.
+fn chebyshev_nodes<T: Value>(n: usize, a: T, b: T) -> Vec<T> {
+    let pi = T::try_cast(std::f64::consts::PI).unwrap_or(T::zero());
+    let two_n = T::try_cast(2 * n).unwrap_or(T::one());
+    let half = T::half();
+    let center = (a + b) * half;
+    let half_width = (b - a) * half;
+
+    (0..n)
+        .map(|k| {
+            let k_t = T::try_cast(2 * k + 1).unwrap_or(T::zero());
+            let theta = pi * k_t / two_n;
+            center + half_width * theta.cos()
+        })
+        .collect()
+}
+
+// =============================================================================
+// SVD solver (standalone, mirrors polyfit's CurveFit::solve_matrix)
+// =============================================================================
+
+/// Solve Ax = b via SVD with polyfit-compatible epsilon and iteration tuning.
+fn solve_svd<T: Value>(a: DMatrix<T>, b: &DVector<T>) -> Result<Vec<T>> {
+    const SVD_ITER_LIMIT: (usize, usize) = (1000, 10_000);
+
+    let size = a.shape();
+    let svd_eps = T::RealField::default_epsilon() * nalgebra::convert(5.0);
+
+    let max_dim = size.0.max(size.1);
+    let iters = max_dim
+        .saturating_mul(max_dim)
+        .clamp(SVD_ITER_LIMIT.0, SVD_ITER_LIMIT.1);
+
+    let decomp =
+        SVD::try_new_unordered(a, true, true, svd_eps, iters).ok_or(Error::DidNotConverge)?;
+
+    let machine_epsilon = T::epsilon();
+    let max_size = size.0.max(size.1);
+    let sigma_max = decomp.singular_values.max();
+    let epsilon = machine_epsilon * T::try_cast(max_size)? * sigma_max;
+
+    let big_x = decomp.solve(b, epsilon).map_err(Error::Algebra)?;
+    let coefficients: Vec<_> = big_x.data.into();
+
+    if coefficients.iter().any(|c| c.is_nan()) {
+        return Err(Error::Algebra("NaN in coefficients"));
+    }
+
+    Ok(coefficients)
+}
+
+// =============================================================================
+// Sanathanan-Koerner fitting
+// =============================================================================
+
+/// Precompute x^0, x^1, ..., x^{max_power-1} for each x value.
+fn precompute_powers<T: Value>(x_values: &[T], max_power: usize) -> Vec<Vec<T>> {
+    x_values
+        .iter()
+        .map(|&x| {
+            let mut powers = Vec::with_capacity(max_power);
+            let mut xj = T::one();
+            for _ in 0..max_power {
+                powers.push(xj);
+                xj *= x;
+            }
+            powers
+        })
+        .collect()
+}
+
+/// Build the weighted linear system for one SK iteration.
+#[allow(clippy::needless_range_loop, clippy::too_many_arguments)]
+fn build_sk_system<T: Value>(
+    data: &[(T, T)],
+    x_powers: &[Vec<T>],
+    c_powers: &[Vec<T>],
+    constraints: &[Constraint<T>],
+    sk_weights: &[T],
+    error_weights: &[T],
+    p_terms: usize,
+    q_free: usize,
+) -> (DMatrix<T>, DVector<T>) {
+    let n = data.len();
+    let total_params = p_terms + q_free;
+    let n_total = n + constraints.len();
+    let mut mat = DMatrix::zeros(n_total, total_params);
+    let mut rhs = DVector::zeros(n_total);
+
+    for i in 0..n {
+        let y = data[i].1;
+        let w = sk_weights[i] * error_weights[i];
+
+        for j in 0..p_terms {
+            mat[(i, j)] = w * x_powers[i][j];
+        }
+        for j in 0..q_free {
+            mat[(i, p_terms + j)] = -w * y * x_powers[i][j];
+        }
+        rhs[i] = w * y * x_powers[i][q_free];
+    }
+
+    for (ci, constraint) in constraints.iter().enumerate() {
+        let row = n + ci;
+        let cw = constraint.weight;
+        for j in 0..p_terms {
+            mat[(row, j)] = cw * c_powers[ci][j];
+        }
+        for j in 0..q_free {
+            mat[(row, p_terms + j)] = -cw * constraint.y * c_powers[ci][j];
+        }
+        rhs[row] = cw * constraint.y * c_powers[ci][q_free];
+    }
+
+    (mat, rhs)
+}
+
+/// Fit P(x)/Q(x) using iteratively reweighted least squares.
+///
+/// The SK algorithm linearizes the rational fitting problem:
+///   `P(x_i) - y_i * Q(x_i) = 0`
+///
+/// With Q monic (`q_n` = 1), this becomes a linear system in the free
+/// parameters `[p_0, ..., p_m, q_0, ..., q_{n-1}]`. Each iteration
+/// reweights by `1/Q(x_i)` from the previous solution, converging to
+/// the true nonlinear least-squares solution.
+fn fit_sk<T: Value>(
+    data: &[(T, T)],
+    p_terms: usize,
+    q_terms: usize,
+    max_iters: usize,
+    tolerance: T,
+    constraints: &[Constraint<T>],
+    weighting: ErrorWeighting,
+) -> Result<(RationalPolynomial<T>, usize)> {
+    let n = data.len();
+    let q_free = q_terms - 1;
+    let total_params = p_terms + q_free;
+
+    let max_power = p_terms.max(q_terms);
+    let data_x: Vec<T> = data.iter().map(|&(x, _)| x).collect();
+    let x_powers = precompute_powers(&data_x, max_power);
+
+    let constraint_x: Vec<T> = constraints.iter().map(|c| c.x).collect();
+    let c_powers = precompute_powers(&constraint_x, max_power);
+
+    let error_weights: Vec<T> = match weighting {
+        ErrorWeighting::Absolute => vec![T::one(); n],
+        ErrorWeighting::Relative => data
+            .iter()
+            .map(|(_, y)| {
+                let ay = Value::abs(*y);
+                if ay.is_near_zero() {
+                    T::one()
+                } else {
+                    T::one() / ay
+                }
+            })
+            .collect(),
+    };
+
+    let mut sk_weights = vec![T::one(); n];
+    let mut prev_params: Vec<T> = vec![T::zero(); total_params];
+    let mut final_p = vec![T::zero(); p_terms];
+    let mut final_q = vec![T::zero(); q_terms];
+    let mut converged_iter = max_iters;
+
+    for iter in 0..max_iters {
+        let (mat, rhs) = build_sk_system(
+            data,
+            &x_powers,
+            &c_powers,
+            constraints,
+            &sk_weights,
+            &error_weights,
+            p_terms,
+            q_free,
+        );
+
+        let params = solve_svd(mat, &rhs)?;
+
+        let p: Vec<T> = params[..p_terms].to_vec();
+        let mut q: Vec<T> = params[p_terms..].to_vec();
+        q.push(T::one());
+
+        // Update SK weights: w_i = 1 / |Q(x_i)|
+        for (i, sw) in sk_weights.iter_mut().enumerate() {
+            let aqx = Value::abs(horner(&q, data[i].0));
+            *sw = if aqx.is_near_zero() {
+                T::try_cast(1e10).unwrap_or(T::one())
+            } else {
+                T::one() / aqx
+            };
+        }
+
+        let max_change = params
+            .iter()
+            .zip(prev_params.iter())
+            .map(|(&new, &old)| {
+                let denom = Value::max(Value::abs(new), Value::abs(old));
+                if denom.is_near_zero() {
+                    T::zero()
+                } else {
+                    Value::abs(new - old) / denom
+                }
+            })
+            .fold(T::zero(), Value::max);
+
+        prev_params.clone_from(&params);
+        final_p = p;
+        final_q = q;
+
+        if max_change < tolerance && iter > 0 {
+            converged_iter = iter + 1;
+            break;
+        }
+    }
+
+    Ok((RationalPolynomial::new(final_p, final_q), converged_iter))
+}
+
+// =============================================================================
+// Top-level fit: SK initialization → LM refinement
+// =============================================================================
+
+/// Fit P(x)/Q(x) using SK initialization, LM refinement, and multi-restart.
+#[allow(clippy::too_many_arguments, clippy::assign_op_pattern)]
+fn fit_rational<T: Value>(
+    data: &[(T, T)],
+    p_terms: usize,
+    q_terms: usize,
+    sk_iters: usize,
+    lm_iters: usize,
+    tolerance: T,
+    constraints: &[Constraint<T>],
+    weighting: ErrorWeighting,
+    constraint_mode: ConstraintMode,
+    restarts: usize,
+) -> Result<(RationalPolynomial<T>, usize)> {
+    let sk_constraints = match constraint_mode {
+        ConstraintMode::SnapOnly => &[] as &[Constraint<T>],
+        ConstraintMode::SkThenSnap | ConstraintMode::SkOnly | ConstraintMode::Both => constraints,
+    };
+
+    let lm_constraints: &[Constraint<T>] = match constraint_mode {
+        ConstraintMode::Both => constraints,
+        _ => &[],
+    };
+
+    let (base_poly, sk_used) = fit_sk(
+        data,
+        p_terms,
+        q_terms,
+        sk_iters,
+        tolerance,
+        sk_constraints,
+        weighting,
+    )?;
+
+    if lm_iters == 0 {
+        let mut poly = base_poly;
+        if matches!(
+            constraint_mode,
+            ConstraintMode::SnapOnly | ConstraintMode::SkThenSnap
+        ) {
+            for c in constraints {
+                poly.snap_boundary(c.x, c.y);
+            }
+        }
+        return Ok((poly, sk_used));
+    }
+
+    // Run LM from SK result (restart 0)
+    let mut best_poly = base_poly.clone();
+    let mut best_lm = refine_lm(
+        &mut best_poly,
+        data,
+        lm_constraints,
+        weighting,
+        lm_iters,
+        tolerance,
+    );
+    let mut best_cost = compute_cost(
+        data,
+        lm_constraints,
+        &pack_params(&best_poly),
+        p_terms,
+        weighting,
+    );
+
+    // Multi-restart: perturb SK result, re-run LM, keep best
+    for r in 1..restarts {
+        let mut poly = base_poly.clone();
+        // Deterministic perturbation using sin/cos with irrational-ish constants
+        let r_f64 = T::try_cast(r).unwrap_or(T::one());
+        for (i, c) in poly.numerator.iter_mut().enumerate() {
+            let phase = r_f64 * T::try_cast(7.319).unwrap_or(T::one())
+                + T::try_cast(i).unwrap_or(T::zero()) * T::try_cast(2.903).unwrap_or(T::one());
+            *c = *c * (T::one() + T::try_cast(0.05).unwrap_or(T::zero()) * phase.sin());
+        }
+        let q_free_len = poly.denominator.len() - 1;
+        for (i, c) in poly.denominator[..q_free_len].iter_mut().enumerate() {
+            let phase = r_f64 * T::try_cast(5.147).unwrap_or(T::one())
+                + T::try_cast(i).unwrap_or(T::zero()) * T::try_cast(3.571).unwrap_or(T::one());
+            *c = *c * (T::one() + T::try_cast(0.05).unwrap_or(T::zero()) * phase.sin());
+        }
+
+        let lm_used = refine_lm(
+            &mut poly,
+            data,
+            lm_constraints,
+            weighting,
+            lm_iters,
+            tolerance,
+        );
+        let cost = compute_cost(
+            data,
+            lm_constraints,
+            &pack_params(&poly),
+            p_terms,
+            weighting,
+        );
+
+        if cost < best_cost {
+            best_poly = poly;
+            best_lm = lm_used;
+            best_cost = cost;
+        }
+    }
+
+    // Post-hoc snap
+    if matches!(
+        constraint_mode,
+        ConstraintMode::SnapOnly | ConstraintMode::SkThenSnap
+    ) {
+        for c in constraints {
+            best_poly.snap_boundary(c.x, c.y);
+        }
+    }
+
+    Ok((best_poly, sk_used + best_lm))
+}
+
+/// Pack polynomial coefficients into a `DVector` for cost computation.
+fn pack_params<T: Value>(poly: &RationalPolynomial<T>) -> DVector<T> {
+    let q_free = poly.denominator.len() - 1;
+    let total = poly.numerator.len() + q_free;
+    let mut params = DVector::zeros(total);
+    for (j, &c) in poly.numerator.iter().enumerate() {
+        params[j] = c;
+    }
+    for (j, &c) in poly.denominator[..q_free].iter().enumerate() {
+        params[poly.numerator.len() + j] = c;
+    }
+    params
+}
+
+// =============================================================================
+// Levenberg-Marquardt refinement
+// =============================================================================
+
+/// Refine a rational polynomial using Levenberg-Marquardt with Nielsen damping.
+///
+/// Uses the analytical Jacobian of P(x)/Q(x):
+///   `∂(P/Q)/∂p_j = x^j / Q(x)`
+///   `∂(P/Q)/∂q_j = -(P/Q) · x^j / Q(x)`
+#[allow(clippy::assign_op_pattern)]
+fn refine_lm<T: Value>(
+    poly: &mut RationalPolynomial<T>,
+    data: &[(T, T)],
+    constraints: &[Constraint<T>],
+    weighting: ErrorWeighting,
+    max_iters: usize,
+    tolerance: T,
+) -> usize {
+    let p_terms = poly.numerator.len();
+    let q_free = poly.denominator.len() - 1; // last is fixed at 1
+    let total_params = p_terms + q_free;
+
+    // Pack parameters into a single vector
+    let mut params = DVector::zeros(total_params);
+    for (j, &c) in poly.numerator.iter().enumerate() {
+        params[j] = c;
+    }
+    for (j, &c) in poly.denominator[..q_free].iter().enumerate() {
+        params[p_terms + j] = c;
+    }
+
+    let mut cost = compute_cost(data, constraints, &params, p_terms, weighting);
+
+    // Initial λ: τ * max(diag(J^T J)) where J is data-only (no constraints)
+    // to avoid constraint weights inflating the initial damping.
+    let (_, j_init) = compute_residuals_jacobian(data, &[], &params, p_terms, weighting);
+    let jtj_init = j_init.transpose() * &j_init;
+    let tau = T::try_cast(1e-3).unwrap_or(T::one());
+    let mut lambda = tau
+        * (0..total_params)
+            .map(|i| Value::abs(jtj_init[(i, i)]))
+            .fold(T::zero(), Value::max);
+    if lambda.is_near_zero() {
+        lambda = T::try_cast(1e-6).unwrap_or(T::one());
+    }
+    drop(j_init);
+    drop(jtj_init);
+
+    let two = T::two();
+    let lm_ftol = T::try_cast(1e-15).unwrap_or(tolerance);
+    let lm_gtol = T::try_cast(1e-15).unwrap_or(tolerance);
+    let mut nu = two; // damping scale factor (Nielsen update)
+    let mut consecutive_rejects = 0_usize;
+    let mut iters_used = 0;
+
+    for _iter in 0..max_iters {
+        iters_used += 1;
+
+        let (residuals, jacobian) =
+            compute_residuals_jacobian(data, constraints, &params, p_terms, weighting);
+        let jtj = &jacobian.transpose() * &jacobian;
+        let jtr = jacobian.transpose() * &residuals;
+
+        // Gradient convergence
+        let grad_norm = jtr
+            .iter()
+            .map(|&g| Value::abs(g))
+            .fold(T::zero(), Value::max);
+        if grad_norm < lm_gtol {
+            break;
+        }
+
+        // Solve (J^T J + λI) Δ = -J^T r
+        let mut damped = jtj.clone();
+        for i in 0..total_params {
+            damped[(i, i)] += lambda;
+        }
+
+        let neg_jtr = -&jtr;
+        let step = match solve_svd(damped, &neg_jtr) {
+            Ok(s) => DVector::from_vec(s),
+            Err(_) => break,
+        };
+
+        // Gain ratio: actual reduction / predicted reduction
+        let trial = &params + &step;
+        let trial_cost = compute_cost(data, constraints, &trial, p_terms, weighting);
+        let actual_reduction = cost - trial_cost;
+
+        // Predicted reduction: step^T (λ * step - J^T r) / 2
+        // (from linearized model: L(Δ) ≈ r^T r + 2 Δ^T J^T r + Δ^T J^T J Δ)
+        let pred_reduction = {
+            let mut ls = &step * lambda;
+            for i in 0..total_params {
+                ls[i] = ls[i] - jtr[i];
+            }
+            step.dot(&ls) * T::half()
+        };
+
+        let gain = if pred_reduction.is_near_zero() {
+            T::zero()
+        } else {
+            actual_reduction / pred_reduction
+        };
+
+        let three_quarter = T::try_cast(0.75).unwrap_or(T::one());
+
+        if gain > T::zero() && actual_reduction > T::zero() {
+            // Accept step
+            params = trial;
+            cost = trial_cost;
+            consecutive_rejects = 0;
+
+            // Nielsen update: reduce λ if gain is good
+            if gain > three_quarter {
+                let third = T::try_cast(1.0 / 3.0).unwrap_or(T::one());
+                let g2 = two * gain - T::one();
+                lambda = lambda * Value::max(third, T::one() - g2 * g2 * g2);
+                nu = two;
+            }
+
+            // Convergence checks
+            let rel_reduction =
+                actual_reduction / Value::max(cost, T::try_cast(1e-30).unwrap_or(T::one()));
+            if rel_reduction < lm_ftol {
+                break;
+            }
+            let step_norm = step
+                .iter()
+                .map(|&s| Value::abs(s))
+                .fold(T::zero(), Value::max);
+            let param_norm = params
+                .iter()
+                .map(|&p| Value::abs(p))
+                .fold(T::one(), Value::max);
+            if step_norm / param_norm < lm_ftol {
+                break;
+            }
+        } else {
+            // Reject: increase λ, widen trust region
+            lambda = lambda * nu;
+            nu = nu * two;
+            consecutive_rejects += 1;
+            if consecutive_rejects > 30 {
+                break;
+            }
+        }
+    }
+
+    // Unpack parameters back into polynomial
+    for j in 0..p_terms {
+        poly.numerator[j] = params[j];
+    }
+    for j in 0..q_free {
+        poly.denominator[j] = params[p_terms + j];
+    }
+    // poly.denominator[q_free] stays 1.0
+
+    iters_used
+}
+
+/// Compute total cost (sum of squared residuals).
+fn compute_cost<T: Value>(
+    data: &[(T, T)],
+    constraints: &[Constraint<T>],
+    params: &DVector<T>,
+    p_terms: usize,
+    weighting: ErrorWeighting,
+) -> T {
+    let q_free = params.len() - p_terms;
+    let p: Vec<T> = (0..p_terms).map(|j| params[j]).collect();
+    let mut q: Vec<T> = (0..q_free).map(|j| params[p_terms + j]).collect();
+    q.push(T::one());
+
+    let mut cost = T::zero();
+    for &(x, y) in data {
+        let pred = horner(&p, x) / horner(&q, x);
+        let r = match weighting {
+            ErrorWeighting::Absolute => pred - y,
+            ErrorWeighting::Relative => {
+                let ay = Value::abs(y);
+                if ay.is_near_zero() {
+                    pred - y
+                } else {
+                    (pred - y) / ay
+                }
+            }
+        };
+        cost += r * r;
+    }
+    for c in constraints {
+        let pred = horner(&p, c.x) / horner(&q, c.x);
+        let r = c.weight * (pred - c.y);
+        cost += r * r;
+    }
+    cost
+}
+
+/// Compute residual vector and analytical Jacobian.
+fn compute_residuals_jacobian<T: Value>(
+    data: &[(T, T)],
+    constraints: &[Constraint<T>],
+    params: &DVector<T>,
+    p_terms: usize,
+    weighting: ErrorWeighting,
+) -> (DVector<T>, DMatrix<T>) {
+    let q_free = params.len() - p_terms;
+    let total_params = params.len();
+    let n_total = data.len() + constraints.len();
+
+    let p: Vec<T> = (0..p_terms).map(|j| params[j]).collect();
+    let mut q: Vec<T> = (0..q_free).map(|j| params[p_terms + j]).collect();
+    q.push(T::one());
+
+    let mut residuals = DVector::zeros(n_total);
+    let mut jacobian = DMatrix::zeros(n_total, total_params);
+
+    for (i, &(x, y)) in data.iter().enumerate() {
+        let qx = horner(&q, x);
+        let px = horner(&p, x);
+        let pred = px / qx;
+        let inv_q = T::one() / qx;
+
+        let (r, w) = match weighting {
+            ErrorWeighting::Absolute => (pred - y, T::one()),
+            ErrorWeighting::Relative => {
+                let ay = Value::abs(y);
+                if ay.is_near_zero() {
+                    (pred - y, T::one())
+                } else {
+                    ((pred - y) / ay, T::one() / ay)
+                }
+            }
+        };
+
+        residuals[i] = r;
+
+        // ∂r/∂p_j = w * x^j / Q(x)
+        let mut xj = T::one();
+        for j in 0..p_terms {
+            jacobian[(i, j)] = w * xj * inv_q;
+            xj *= x;
+        }
+
+        // ∂r/∂q_j = -w * pred * x^j / Q(x)
+        let mut xj = T::one();
+        for j in 0..q_free {
+            jacobian[(i, p_terms + j)] = -w * pred * xj * inv_q;
+            xj *= x;
+        }
+    }
+
+    for (ci, constraint) in constraints.iter().enumerate() {
+        let row = data.len() + ci;
+        let x = constraint.x;
+        let cw = constraint.weight;
+        let qx = horner(&q, x);
+        let px = horner(&p, x);
+        let pred = px / qx;
+        let inv_q = T::one() / qx;
+
+        residuals[row] = cw * (pred - constraint.y);
+
+        let mut xj = T::one();
+        for j in 0..p_terms {
+            jacobian[(row, j)] = cw * xj * inv_q;
+            xj *= x;
+        }
+        let mut xj = T::one();
+        for j in 0..q_free {
+            jacobian[(row, p_terms + j)] = -cw * pred * xj * inv_q;
+            xj *= x;
+        }
+    }
+
+    (residuals, jacobian)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fit a simple polynomial (no denominator needed): y = x²
+    #[test]
+    fn fit_polynomial_trivial() {
+        let data: Vec<(f64, f64)> = (0..=100)
+            .map(|i| {
+                let x = f64::from(i) / 100.0;
+                (x, x * x)
+            })
+            .collect();
+
+        let fit = RationalFit::new(&data[..], 2, 0, RationalFitOptions::default()).unwrap();
+
+        assert!(fit.r_squared() > 0.999_999, "R² = {}", fit.r_squared());
+
+        // P should be ~[0, 0, 1], Q should be ~[1]
+        let (p, q) = fit.coefficients();
+        assert!(p[0].abs() < 1e-6, "p[0] = {}", p[0]);
+        assert!(p[1].abs() < 1e-6, "p[1] = {}", p[1]);
+        assert!((p[2] - 1.0).abs() < 1e-6, "p[2] = {}", p[2]);
+        assert!((q[0] - 1.0).abs() < 1e-6, "q[0] = {}", q[0]);
+    }
+
+    /// Fit x^2.4 on [0.04, 1.0] — the sRGB EOTF power segment
+    #[test]
+    fn fit_srgb_power() {
+        let fit = RationalFit::from_function(
+            |x: f64| x.powf(2.4),
+            0.04..=1.0,
+            4,
+            4,
+            RationalFitOptions::default(),
+        )
+        .unwrap();
+
+        assert!(fit.r_squared() > 0.999_999, "R² = {}", fit.r_squared());
+
+        // Check max error is small
+        let max_err = fit.max_abs_error();
+        assert!(max_err < 1e-5, "max abs error = {max_err:.2e}");
+    }
+
+    /// Fit with relative error weighting
+    #[test]
+    fn fit_relative_error() {
+        let options = RationalFitOptions {
+            weighting: ErrorWeighting::Relative,
+            ..RationalFitOptions::default()
+        };
+
+        let fit =
+            RationalFit::from_function(|x: f64| x.powf(2.4), 0.04..=1.0, 4, 4, options).unwrap();
+
+        assert!(fit.r_squared() > 0.999_999, "R² = {}", fit.r_squared());
+        assert!(
+            fit.max_rel_error() < 1e-4,
+            "max rel error = {:.2e}",
+            fit.max_rel_error()
+        );
+    }
+
+    /// Fit with a boundary constraint
+    #[test]
+    fn fit_with_constraint() {
+        let target_x: f64 = 0.04;
+        let target_y = target_x.powf(2.4);
+
+        let options = RationalFitOptions {
+            constraints: vec![Constraint::new(target_x, target_y)],
+            ..RationalFitOptions::default()
+        };
+
+        let fit =
+            RationalFit::from_function(|x: f64| x.powf(2.4), 0.04..=1.0, 4, 4, options).unwrap();
+
+        // The constraint point should be very accurate
+        let err_at_constraint = (fit.y(target_x) - target_y).abs();
+        assert!(
+            err_at_constraint < 1e-10,
+            "error at constraint = {err_at_constraint:.2e}"
+        );
+    }
+
+    /// Asymmetric degrees: 3/4
+    #[test]
+    fn fit_asymmetric_degrees() {
+        let fit = RationalFit::from_function(
+            |x: f64| x.powf(2.4),
+            0.04..=1.0,
+            3,
+            4,
+            RationalFitOptions::default(),
+        )
+        .unwrap();
+
+        let (p, q) = fit.coefficients();
+        assert_eq!(p.len(), 4); // 3 + 1
+        assert_eq!(q.len(), 5); // 4 + 1
+        assert!((q[4] - 1.0).abs() < 1e-15, "Q must be monic");
+        assert!(fit.r_squared() > 0.9999, "R² = {}", fit.r_squared());
+    }
+
+    /// Fit log2(x) on [0.5, 2.0] — transcendental approximation
+    #[test]
+    fn fit_log2() {
+        let fit = RationalFit::from_function(
+            |x: f64| x.log2(),
+            0.5..=2.0,
+            3,
+            3,
+            RationalFitOptions::default(),
+        )
+        .unwrap();
+
+        assert!(fit.r_squared() > 0.999_999, "R² = {}", fit.r_squared());
+        assert!(
+            fit.max_abs_error() < 1e-6,
+            "max abs error = {:.2e}",
+            fit.max_abs_error()
+        );
+    }
+
+    /// Fit 2^x on [0, 1] — transcendental approximation
+    #[test]
+    fn fit_exp2() {
+        let fit = RationalFit::from_function(
+            |x: f64| (2.0_f64).powf(x),
+            0.0..=1.0,
+            3,
+            3,
+            RationalFitOptions::default(),
+        )
+        .unwrap();
+
+        assert!(fit.r_squared() > 0.999_999, "R² = {}", fit.r_squared());
+        assert!(
+            fit.max_abs_error() < 1e-6,
+            "max abs error = {:.2e}",
+            fit.max_abs_error()
+        );
+    }
+
+    /// Display formatting
+    #[test]
+    fn display_rational() {
+        let poly = RationalPolynomial::new(vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 1.0]);
+        let s = format!("{poly}");
+        assert!(s.contains("1.000000e0"), "display: {s}");
+        assert!(s.contains('/'), "display: {s}");
+    }
+
+    /// R² of a perfect fit
+    #[test]
+    fn r_squared_perfect() {
+        let data: Vec<(f64, f64)> = (0..=100)
+            .map(|i| {
+                let x = f64::from(i) / 100.0 + 0.01;
+                (x, 1.0 / x)
+            })
+            .collect();
+
+        let fit = RationalFit::new(&data[..], 0, 1, RationalFitOptions::default()).unwrap();
+        assert!(
+            fit.r_squared() > 0.99999,
+            "R² for 1/x with 0/1 rational = {}",
+            fit.r_squared()
+        );
+    }
+
+    /// Convergence tracking
+    #[test]
+    fn iterations_tracked() {
+        let fit = RationalFit::from_function(
+            |x: f64| x * x,
+            0.0..=1.0,
+            2,
+            0,
+            RationalFitOptions::default(),
+        )
+        .unwrap();
+
+        // Should converge quickly for a trivial case
+        assert!(fit.iterations() <= 50, "iterations = {}", fit.iterations());
+    }
+
+    /// f32 support
+    #[test]
+    fn fit_f32() {
+        let data: Vec<(f32, f32)> = (1..=100)
+            .map(|i| {
+                let x = i as f32 / 100.0;
+                (x, x.powf(2.4))
+            })
+            .collect();
+
+        let options = RationalFitOptions::<f32>::default();
+        let fit = RationalFit::new(&data[..], 4, 4, options).unwrap();
+        assert!(fit.r_squared() > 0.9999, "R² = {}", fit.r_squared());
+    }
+
+    /// sRGB EOTF with boundary constraint — matches the Python fitting scripts
+    #[test]
+    fn fit_srgb_with_constraint() {
+        let a: f64 = 0.055_010_718_947_586_6;
+        let a1: f64 = 1.0 + a;
+        let threshold_gamma: f64 = 12.92 * 0.003_041_282_560_127_521;
+        let threshold_linear: f64 = 0.003_041_282_560_127_521;
+
+        let s2l = |x: f64| ((x + a) / a1).powf(2.4);
+
+        let options = RationalFitOptions {
+            weighting: ErrorWeighting::Relative,
+            constraints: vec![Constraint::new(threshold_gamma, threshold_linear)],
+            n_samples: 5000,
+            ..RationalFitOptions::default()
+        };
+
+        let fit = RationalFit::from_function(s2l, threshold_gamma..=1.0, 4, 4, options).unwrap();
+
+        assert!(fit.r_squared() > 0.999_999, "R² = {}", fit.r_squared());
+        assert!(
+            fit.max_rel_error() < 1e-4,
+            "max rel = {:.2e}",
+            fit.max_rel_error()
+        );
+
+        // Boundary constraint should be very tight
+        let err = (fit.y(threshold_gamma) - threshold_linear).abs();
+        assert!(err < 1e-10, "boundary err = {err:.2e}");
+    }
+
+    /// LM refinement improves constrained sRGB fit over SK alone
+    #[test]
+    fn lm_improves_constrained_srgb() {
+        let a: f64 = 0.055_010_718_947_586_6;
+        let a1: f64 = 1.0 + a;
+        let threshold_gamma: f64 = 12.92 * 0.003_041_282_560_127_521;
+        let threshold_linear: f64 = 0.003_041_282_560_127_521;
+        let s2l = |x: f64| ((x + a) / a1).powf(2.4);
+
+        let base_options = RationalFitOptions {
+            weighting: ErrorWeighting::Relative,
+            constraints: vec![Constraint::new(threshold_gamma, threshold_linear)],
+            constraint_mode: ConstraintMode::Both,
+            n_samples: 5000,
+            ..RationalFitOptions::default()
+        };
+
+        // SK only (with constraints applied during SK)
+        let sk_options = RationalFitOptions {
+            lm_iterations: 0,
+            constraint_mode: ConstraintMode::SkOnly,
+            ..base_options.clone()
+        };
+        let sk_fit =
+            RationalFit::from_function(s2l, threshold_gamma..=1.0, 4, 4, sk_options).unwrap();
+
+        // SK + LM (both with constraints)
+        let lm_fit =
+            RationalFit::from_function(s2l, threshold_gamma..=1.0, 4, 4, base_options).unwrap();
+
+        let sk_err = sk_fit.max_rel_error();
+        let lm_err = lm_fit.max_rel_error();
+
+        // LM should significantly improve the constrained case
+        assert!(
+            lm_err < sk_err,
+            "LM should improve: SK={sk_err:.2e}, LM={lm_err:.2e}"
+        );
+        assert!(
+            lm_err < 1e-4,
+            "LM should reach <1e-4 relative error, got {lm_err:.2e}"
+        );
+    }
+
+    /// Boundary error report
+    #[test]
+    fn boundary_report() {
+        let fit = RationalFit::from_function(
+            |x: f64| x.powf(2.4),
+            0.04..=1.0,
+            4,
+            4,
+            RationalFitOptions::default(),
+        )
+        .unwrap();
+
+        let report = fit.boundary_error(|x| x.powf(2.4));
+
+        // At domain endpoints, error should be small
+        assert!(
+            report.lo.rel_err < 1e-3,
+            "lo rel err = {:.2e}",
+            report.lo.rel_err
+        );
+        assert!(
+            report.hi.rel_err < 1e-4,
+            "hi rel err = {:.2e}",
+            report.hi.rel_err
+        );
+
+        // Extrapolation points are populated
+        assert_eq!(report.past_lo.len(), 4);
+        assert_eq!(report.past_hi.len(), 4);
+
+        // Extrapolation points are at the expected offsets
+        let width = 1.0 - 0.04;
+        assert!(
+            (report.past_lo[0].x - (0.04 - width * 0.001)).abs() < 1e-10,
+            "past_lo[0] at wrong x"
+        );
+        assert!(
+            (report.past_hi[0].x - (1.0 + width * 0.001)).abs() < 1e-10,
+            "past_hi[0] at wrong x"
+        );
+
+        // Display works without panic
+        let s = format!("{report}");
+        assert!(s.contains("Boundary error"), "display: {s}");
+        assert!(s.contains("Extrapolation past lo"), "display: {s}");
+    }
+
+    /// Self-consistency: `optimize_f32`'s reported metrics must match an
+    /// independent recomputation over the same sweep. This guards against
+    /// regressions where the scorer and the final measurement disagree.
+    #[test]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_lossless,
+        clippy::cast_precision_loss
+    )]
+    fn f32_search_result_is_self_consistent() {
+        let fit = RationalFit::from_function(
+            |x: f64| x.powf(2.4),
+            0.04..=1.0,
+            4,
+            4,
+            RationalFitOptions {
+                weighting: ErrorWeighting::Relative,
+                n_samples: 5000,
+                restarts: 4,
+                ..RationalFitOptions::default()
+            },
+        )
+        .unwrap();
+
+        let result = fit.as_polynomial().optimize_f32(
+            |x: f64| x.powf(2.4),
+            0.04_f32,
+            1.0_f32,
+            |v| v,
+            F32SearchConfig {
+                samples: Some(50_000),
+                ..F32SearchConfig::default()
+            },
+        );
+
+        // Independently recompute the metrics from the returned coefficients.
+        // MUST use the same sampling convention as the library:
+        // lo/hi are promoted via f64::from(f32), not the f64 literal.
+        let mut max_ulp = 0_u32;
+        let mut max_abs: f64 = 0.0;
+        let n = 50_000;
+        let lo = f64::from(0.04_f32);
+        let hi = f64::from(1.0_f32);
+        for i in 0..=n {
+            let v = lo + (hi - lo) * i as f64 / n as f64;
+            let got = eval_f32_horner(v as f32, &result.numerator, &result.denominator);
+            let expected = v.powf(2.4) as f32;
+            let ulp = f32_ulp_distance(got, expected);
+            if ulp > max_ulp {
+                max_ulp = ulp;
+            }
+            let a = (f64::from(got) - f64::from(expected)).abs();
+            if a > max_abs {
+                max_abs = a;
+            }
+        }
+
+        assert_eq!(
+            result.max_ulp, max_ulp,
+            "reported max_ulp {} does not match independent recomputation {}",
+            result.max_ulp, max_ulp
+        );
+        assert!(
+            (result.max_abs_err - max_abs).abs() < 1e-15 * max_abs.max(1e-30),
+            "reported max_abs {} differs from recomputation {}",
+            result.max_abs_err,
+            max_abs
+        );
+        assert_eq!(result.values_scored, u64::try_from(n + 1).unwrap());
+        assert!(!result.exhaustive);
+    }
+
+    /// Piecewise gap detects the discontinuity between linear and polynomial
+    /// branches, which `boundary_ulp` alone misses.
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+    fn piecewise_gap_matching_branches_is_small() {
+        // Build a contrived piecewise: f(v) = v on both sides of threshold.
+        // The polynomial fit to f(v)=v on [0.5, 1] should produce a small gap
+        // to the identity linear branch v.
+        let fit = RationalFit::from_function(
+            |x: f64| x,
+            0.5..=1.0,
+            2,
+            2,
+            RationalFitOptions {
+                weighting: ErrorWeighting::Absolute,
+                n_samples: 1000,
+                restarts: 2,
+                ..RationalFitOptions::default()
+            },
+        )
+        .unwrap();
+
+        let (p64, q64) = fit.coefficients();
+        let p: Vec<f32> = p64.iter().map(|&c| c as f32).collect();
+        let q: Vec<f32> = q64.iter().map(|&c| c as f32).collect();
+
+        // Gap between identity branch and polynomial approximation of identity.
+        // Should be small (≤ a few ULPs) since both branches compute the same thing.
+        let gap = piecewise_gap(0.5_f32, &p, &q, |v| v, |v| v);
+        assert!(
+            gap < 100,
+            "piecewise gap for matching identity branches: {gap}"
+        );
+    }
+
+    /// Piecewise gap correctly identifies a deliberately mismatched pair
+    /// (documents the diagnostic value of the metric).
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+    fn piecewise_gap_detects_mismatched_branches() {
+        // Fit f(v) = 2v on [0.5, 1] but pretend the linear branch is v (wrong).
+        let fit = RationalFit::from_function(
+            |x: f64| 2.0 * x,
+            0.5..=1.0,
+            2,
+            2,
+            RationalFitOptions {
+                weighting: ErrorWeighting::Absolute,
+                n_samples: 1000,
+                restarts: 2,
+                ..RationalFitOptions::default()
+            },
+        )
+        .unwrap();
+
+        let (p64, q64) = fit.coefficients();
+        let p: Vec<f32> = p64.iter().map(|&c| c as f32).collect();
+        let q: Vec<f32> = q64.iter().map(|&c| c as f32).collect();
+
+        // Gap between identity branch (wrong) and polynomial (2v)
+        // should be large — that's the whole point of the metric.
+        let gap = piecewise_gap(0.5_f32, &p, &q, |v| v, |v| v);
+        assert!(
+            gap > 1_000_000,
+            "piecewise gap should flag mismatched branches, got {gap}"
+        );
+    }
+
+    /// Roundtrip measurement returns consistent metrics.
+    #[test]
+    #[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
+    fn roundtrip_measurement_consistent() {
+        // Trivial identity roundtrip: f(v)=v, inverse(u)=u → 0 error everywhere.
+        let report = measure_roundtrip(|v| v, |u| u, 0.0, 1.0, Some(1000));
+        assert_eq!(report.max_ulp, 0);
+        assert!(report.max_abs_err == 0.0);
+        assert_eq!(report.u16_over_1, 0);
+        assert_eq!(report.u8_over_half, 0);
+        assert_eq!(report.values_scored, 1001);
+        assert!(!report.exhaustive);
+
+        // Forward then inverse with f32 rounding introduces some error.
+        let report2 = measure_roundtrip(
+            |v: f32| (f64::from(v) * 2.0) as f32,
+            |u: f32| (f64::from(u) * 0.5) as f32,
+            0.01_f32,
+            1.0_f32,
+            Some(1000),
+        );
+        // The composition is exact for these doubling/halving operations when
+        // f32 stays in [0.01, 1.0]. Max error should be tiny.
+        assert!(report2.max_abs_err < 1e-6);
+
+        // Display doesn't panic.
+        let _ = format!("{report}");
+    }
+}

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -133,13 +133,44 @@ pub enum ConstraintMode {
 }
 
 /// A point constraint: the rational polynomial must pass through (x, y).
+///
+/// # All `Constraint` weights are *soft* penalties, not hard pins
+///
+/// Despite the name and the default weight of `1e6`, every `Constraint`
+/// participates in the fit's least-squares objective as a
+/// `weight * (P(x_i)/Q(x_i) - y_i)²` term — a *penalty*, not a *pin*.
+/// The Sanathanan-Koerner iteration and the Levenberg-Marquardt
+/// refinement will trade a small constraint violation for a small
+/// bulk-domain accuracy gain whenever the overall objective improves.
+/// Even with `weight = 1e6` the fitted polynomial can drift from the
+/// constraint point — for `f(0) = 0` in particular, expect drift on the
+/// order of the bulk-domain absolute error.
+///
+/// If you need an *exact* hit at the constraint point (e.g., to make a
+/// piecewise function continuous at its threshold), use
+/// [`ConstraintMode::SnapOnly`] (the default) or
+/// [`ConstraintMode::SkThenSnap`]: after fitting, the constant term
+/// `p[0]` is adjusted so `P(x)/Q(x) = y` exactly at the constraint
+/// point. See [`RationalPolynomial::snap_boundary`] for the math.
+///
+/// For the special case `f(0) = 0` with the goal of saving a constant
+/// load in a SIMD evaluator: a "substitution trick" is more reliable
+/// than any constraint — fit `f(x)/x` (or `f(√x)/√x` etc.) and
+/// multiply by `x` at evaluation time, which makes `c[0] = 0` exact by
+/// construction.
 #[derive(Debug, Clone, Copy)]
 pub struct Constraint<T: Value = f64> {
     /// The x coordinate of the constraint.
     pub x: T,
     /// The y value the rational polynomial must match.
     pub y: T,
-    /// How strongly to enforce (default: 1e6). Higher = harder constraint.
+    /// How strongly to weight this constraint in the least-squares
+    /// objective (default: `1e6`).
+    ///
+    /// **This is a soft penalty multiplier, not a hard equality** —
+    /// arbitrarily large weights still let the optimizer trade a tiny
+    /// constraint residual for a bulk-domain accuracy gain. See the
+    /// [`Constraint`] type-level docs for the workaround.
     pub weight: T,
 }
 
@@ -369,7 +400,14 @@ impl Default for RationalFitOptions<f32> {
 }
 
 impl<T: Value> Constraint<T> {
-    /// Create a hard constraint at (x, y) with default weight 1e6.
+    /// Create a soft point constraint at `(x, y)` with the default
+    /// weight `1e6`.
+    ///
+    /// **Despite the high default weight, this is not a hard pin** —
+    /// see the [`Constraint`] type-level docs. For an exact-match
+    /// guarantee at the constraint point, pair this with
+    /// [`ConstraintMode::SnapOnly`] (the default) or
+    /// [`ConstraintMode::SkThenSnap`].
     pub fn new(x: T, y: T) -> Self {
         Self {
             x,
@@ -378,9 +416,27 @@ impl<T: Value> Constraint<T> {
         }
     }
 
-    /// Create a constraint with custom weight.
-    pub fn with_weight(x: T, y: T, weight: T) -> Self {
+    /// Create a soft point constraint at `(x, y)` with a caller-chosen
+    /// penalty weight.
+    ///
+    /// The `weight` is a multiplier on the `(P(x)/Q(x) - y)²` term in
+    /// the least-squares objective — **not a hard equality**. Arbitrarily
+    /// large weights are tolerated by SK/LM but never produce an exact
+    /// pin. For exact-match behavior at the constraint point, see the
+    /// [`Constraint`] type-level docs.
+    pub fn soft(x: T, y: T, weight: T) -> Self {
         Self { x, y, weight }
+    }
+
+    /// Create a constraint with custom weight.
+    ///
+    /// This is the historical name for [`Constraint::soft`] — both
+    /// produce identical soft (penalty-weighted) constraints. New code
+    /// should prefer [`Constraint::soft`] because the name does not
+    /// invite the misreading "high weight = hard pin." See the
+    /// [`Constraint`] type-level docs.
+    pub fn with_weight(x: T, y: T, weight: T) -> Self {
+        Self::soft(x, y, weight)
     }
 }
 
@@ -2494,5 +2550,29 @@ mod tests {
 
         // Display doesn't panic.
         let _ = format!("{report}");
+    }
+
+    /// `Constraint::soft` is a direct alias for `with_weight` — both
+    /// produce identical constraints with identical fit behavior. New
+    /// callers should prefer `soft` because the name doesn't invite the
+    /// misreading "high weight = hard pin."
+    #[test]
+    fn constraint_soft_is_with_weight_alias() {
+        let a = Constraint::<f64>::soft(0.5, 0.25, 1e3);
+        let b = Constraint::<f64>::with_weight(0.5, 0.25, 1e3);
+        assert_eq!(a.x.to_bits(), b.x.to_bits());
+        assert_eq!(a.y.to_bits(), b.y.to_bits());
+        assert_eq!(a.weight.to_bits(), b.weight.to_bits());
+
+        // And the new constructor produces a usable constraint that the
+        // fitter accepts end-to-end (smoke check — does not assert exact
+        // boundary match because soft constraints don't pin).
+        let options = RationalFitOptions {
+            constraints: vec![Constraint::soft(0.04, (0.04_f64).powf(2.4), 1e6)],
+            ..RationalFitOptions::default()
+        };
+        let fit =
+            RationalFit::from_function(|x: f64| x.powf(2.4), 0.04..=1.0, 4, 4, options).unwrap();
+        assert!(fit.r_squared() > 0.999_999, "R² = {}", fit.r_squared());
     }
 }

--- a/src/rational.rs
+++ b/src/rational.rs
@@ -273,12 +273,45 @@ impl<T: Value> fmt::Display for BoundaryReport<T> {
 }
 
 /// How the f32 search scores candidate coefficients.
+///
+/// # When NOT to trust [`F32ScoreMetric::Ulp`]
+///
+/// The ULP metric measures distance in units-in-the-last-place of the
+/// reference function's f32 output. **ULP distance balloons whenever the
+/// reference output approaches zero** because f32 has very fine resolution
+/// near zero (a single bit-flip near subnormal magnitudes can correspond to
+/// `~1e9` ULPs). For these reference functions, switch to
+/// [`F32ScoreMetric::AbsoluteError`]:
+///
+/// - `x^p` for `0 < p < 1` (square root, cube root, the sRGB `1/2.4`
+///   exponent) on any domain that includes `x ≈ 0`
+/// - `log(x)`, `ln(1+x)`, `arcsinh(x)` near `x = 0`
+/// - `1/x` and other functions whose output passes near zero
+/// - Any function whose codomain spans many orders of magnitude
+///
+/// As a rule of thumb: if `min(|f(x)|) < 1e-2 * max(|f(x)|)` over the
+/// sweep domain, the ULP metric will report misleading numbers and you
+/// should use absolute error instead. A sub-`1e-4` absolute-error fit can
+/// trivially show `max_ulp ≈ 1e9` for these functions while being entirely
+/// usable.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum F32ScoreMetric {
-    /// Score by ULP distance (best for transfer functions with bounded output).
+    /// Score by ULP distance.
+    ///
+    /// Best for transfer functions whose output stays bounded *away from
+    /// zero* (sRGB EOTF on `[threshold, 1]`, PQ on `[threshold, 1]`, etc.)
+    /// where the f32 ULP grid is uniform enough that ULPs track absolute
+    /// error linearly. See the enum-level documentation for the cases
+    /// where this metric is misleading.
     #[default]
     Ulp,
-    /// Score by absolute error (best when output crosses zero, e.g., log2 mantissa).
+    /// Score by absolute error.
+    ///
+    /// Use when the reference output passes near zero (output crosses
+    /// zero, or is dense near subnormal magnitudes), where ULP distance
+    /// stops tracking absolute error linearly. Specifically: `x^p` for
+    /// `0 < p < 1`, `log(x)` near zero, mantissa-of-`log2` style outputs,
+    /// or any function whose codomain spans many decades.
     AbsoluteError,
 }
 
@@ -309,6 +342,27 @@ impl Default for F32SearchConfig {
 }
 
 /// Result of f32 coefficient optimization.
+///
+/// # Picking the right quality metric
+///
+/// Both the ULP fields (`max_ulp`, `avg_ulp`, `boundary_ulp`) and the
+/// absolute-error fields (`max_abs_err`, `avg_abs_err`) are reported on
+/// every result regardless of which [`F32ScoreMetric`] the optimizer
+/// scored against. The "right" number to read depends on the reference
+/// function:
+///
+/// - If the reference output stays bounded *away from zero* over the
+///   sweep domain (most piecewise transfer functions in their power
+///   segment): trust `max_ulp` / `boundary_ulp`.
+/// - If the reference output approaches zero anywhere in the sweep
+///   domain (`x^p` for `0 < p < 1`, `log(x)`, `1/x`, anything whose
+///   codomain spans many decades): the ULP fields will look
+///   catastrophic (often `~1e9`) even for sub-`1e-4` fits — read
+///   `max_abs_err` instead. See [`F32ScoreMetric`] for the full
+///   discussion.
+///
+/// `mono_violations` and `values_scored` / `exhaustive` are unconditional
+/// quality signals.
 #[derive(Debug, Clone)]
 pub struct F32SearchResult {
     /// Optimized f32 numerator coefficients.
@@ -316,14 +370,29 @@ pub struct F32SearchResult {
     /// Optimized f32 denominator coefficients.
     pub denominator: Vec<f32>,
     /// Maximum ULP error across the sweep domain.
+    ///
+    /// **Unreliable when the reference output approaches zero** — read
+    /// `max_abs_err` instead in that case. See [`F32SearchResult`]'s
+    /// type-level docs for guidance.
     pub max_ulp: u32,
     /// Average ULP error across the sweep domain.
+    ///
+    /// See the caveat on `max_ulp`: ULP averaging is also distorted when
+    /// the reference output approaches zero.
     pub avg_ulp: f64,
     /// ULP error at the domain start (boundary).
+    ///
+    /// See the caveat on `max_ulp`: if `sweep_lo` is near zero for a
+    /// fractional-power-style reference function, this number will look
+    /// huge even for a usable fit.
     pub boundary_ulp: u32,
     /// Number of monotonicity violations.
     pub mono_violations: u64,
     /// Maximum absolute error.
+    ///
+    /// The "ground truth" quality number when the reference output
+    /// approaches zero — see the caveats on the ULP fields and the
+    /// [`F32ScoreMetric`] docs.
     pub max_abs_err: f64,
     /// Average absolute error.
     pub avg_abs_err: f64,


### PR DESCRIPTION
5 commits ahead of master:

- de3b6ed  Add rational polynomial P(x)/Q(x) fitting module
- d454f83  Add public Horner-form evaluation helpers in polyfit::eval
- 6e84952  Warn that as_monomial loses precision on wide-domain fits
- c4c5c13  Add Constraint::soft alias for with_weight; clarify weights are soft penalties
- 4de8e99  Warn that F32 ULP metric is unreliable when reference output approaches zero

The rational module is the bulk (Sanathanan-Koerner + Levenberg-Marquardt, constraints, 5 examples, ~2,647 LOC in src/rational.rs).

I've been using polyfit for magetypes (SIMD primitive types for the archmage crate, vector-width polynomial evaluators for transcendentals) plus various AI/numerical experiments. The four small follow-up commits address rough edges hit while driving the library — most recently fitting f(x) = x^(1/2.4) on [0, 12] for a SIMD hot loop in zentone:

- **polyfit::eval** module — every caller shipping a polyfit-derived polynomial ends up re-implementing the same Horner-form evaluator. Exposes `horner_f32`, `horner_f64`, `horner_f32_via_f64`, and `rational_horner_f32_via_f64` (the last is bit-identical to the internal scorer in `RationalPolynomial::optimize_f32`, verified by a parity test at 200 sample points).

- **Constraint::soft alias for with_weight** — the `with_weight(0.0, 0.0, 1e6)` API name suggests a near-hard pin, but the weight is a soft LS penalty and SK iteration drifts (boundary ulp ~8.5e8 even with `1e6` set). Adds `Constraint::soft` as the clearer name and strengthens the type-level docs to spell out that all weights are soft. `with_weight` stays as an alias; no API break.

- **as_monomial precision warning** — `ChebyshevBasis::as_monomial()` silently loses precision past ~degree 12 on wide domains (Vandermonde-style condition number explodes). On `[0, 12]` `√x`-substituted fit of `x^(1/2.4)`: direct Chebyshev evaluation stable past degree 20, monomial after `as_monomial` gives 8.0e-3 at deg 12, 1.9e-1 at deg 14. Adds a doc warning with a degree/domain-half-width stable/risky table.

- **F32 ULP metric warning** — `F32SearchResult::max_ulp` is technically correct but useless as a quality signal when the reference output approaches zero. On `f(x) = x^(1/2.4)` every candidate fit reported `max_ulp ≈ 1e9` even when `max_abs_err < 5e-4`. Adds doc warnings on `F32ScoreMetric::Ulp` and the relevant fields listing trap-case reference functions and a rule of thumb for switching to `AbsoluteError`.

## Known limitation

SK iteration is unstable on functions with a singular tangent at the fit-domain boundary (`f'(x_0) → ∞` for some `x_0 ∈ {a, b}`). Concretely, fitting `f(x) = x^(1/2.4)` on `[0, 12]` produces non-monotonic `max_abs` across `(p_deg, q_deg)`: `(3,3) → 2.2e-2`, `(4,4) → 4.1e-2`, `(5,4) → 3.7e-2`, `(6,5) → 5.8e-2`. Even with `restarts=8` and `n_samples=40000` the fitter consistently lands on bad local minima. Workaround: sqrt substitution (`g(z) = z^(2/2.4)` for `z = √x`) flattens the singular tangent and produces clean monomial fits (3.44e-4 max abs error with a 2-piece monomial split at `√0.07`). Could be addressed in a follow-up PR via either a `RationalFit::from_function_with_transform` constructor or a sqrt-substitution heuristic in the SK fitter when a boundary singular tangent is detected.

All gates pass: build, test (123 lib + 118 doc + 2 ignored), fmt, clippy, doc, bench, rdme. No new clippy warnings.

Draft because the rational module is large enough to want a real look before merge.